### PR TITLE
Add API endpoint to give a UUID's ingest history

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'mysql2', '~> 0.4.5' #used to connect to Filestore Databases
 gem 'jbuilder', '~> 2.5'
 gem 'rubydora', '~> 2.0'
 gem 'http', '~> 3.0'
+gem 'will_paginate', '~> 3.1', '>= 3.1.6'
 
 group :test do
   gem 'shoulda-matchers', '~> 3.1', '>= 3.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    will_paginate (3.1.6)
 
 PLATFORMS
   ruby
@@ -264,6 +265,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  will_paginate (~> 3.1, >= 3.1.6)
 
 BUNDLED WITH
    1.16.1

--- a/app/controllers/ingest_history_controller.rb
+++ b/app/controllers/ingest_history_controller.rb
@@ -1,0 +1,7 @@
+class IngestHistoryController < ApplicationController
+  # An API endpoint of any UUID's (paginated) histroy
+  def show
+    @ingest_requests = IngestRequest.where(uuid: params[:id]).order('created_at DESC').paginate(page: params[:page], per_page: 500)
+    render json: @ingest_requests
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-   resources :ingest_requests, only: :create, defaults: {format: :json}
+   resources :ingest_requests, only: [:create], defaults: {format: :json}
+   resources :ingest_history, only: [:show], defaults: {format: :json}
 end


### PR DESCRIPTION
This adds an endpoint that reveals a (paginated) history of a UUID.
