### PR TITLE
Change :content_type to :mimeType when creating datastream.

### DIFF
--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -31,14 +31,14 @@ IngestJob = Struct.new(:ingest_request_id) do
       digital_object.models << 'info:fedora/nypl-model:image'
 
       # Datastreams with info from the `Item` Level
-      fedora_client.repository.add_datastream(pid: pid, dsid: 'MODSXML', content: mods, content_type: 'text/xml', checksumType: 'MD5', dsLabel: 'MODS XML record for this object')
-      fedora_client.repository.add_datastream(pid: pid, dsid: 'RIGHTS',  content: rights, content_type: 'text/xml', checksumType: 'MD5', dsLabel: 'Rights XML record for this object')
-      fedora_client.repository.add_datastream(pid: pid, dsid: 'DC',      content: dublin_core, formatURI: 'http://www.openarchives.org/OAI/2.0/oai_dc/', content_type: 'text/xml', checksumType: 'MD5', dsLabel: 'DC XML record for this object')
+      fedora_client.repository.add_datastream(pid: pid, dsid: 'MODSXML', content: mods, mimeType: 'text/xml', checksumType: 'MD5', dsLabel: 'MODS XML record for this object')
+      fedora_client.repository.add_datastream(pid: pid, dsid: 'RIGHTS',  content: rights, mimeType: 'text/xml', checksumType: 'MD5', dsLabel: 'Rights XML record for this object')
+      fedora_client.repository.add_datastream(pid: pid, dsid: 'DC',      content: dublin_core, formatURI: 'http://www.openarchives.org/OAI/2.0/oai_dc/', mimeType: 'text/xml', checksumType: 'MD5', dsLabel: 'DC XML record for this object')
 
       rels_ext = mms_client.rels_ext_for(uuid)
 
       # Datastreams with info from the `Capture` Level
-      fedora_client.repository.add_datastream(pid: pid, dsid: 'RELS-EXT', content: rels_ext, content_type: 'application/rdf+xml', checksumType: 'MD5', dsLabel: 'RELS-EXT XML record for this object')
+      fedora_client.repository.add_datastream(pid: pid, dsid: 'RELS-EXT', content: rels_ext, mimeType: 'application/rdf+xml', checksumType: 'MD5', dsLabel: 'RELS-EXT XML record for this object')
       digital_object.save
       Delayed::Worker.logger.debug({ uuid: pid, message: 'done ingesting' }.to_json)
     end


### PR DESCRIPTION
Hey @emu47 

Despite the big looking diff - all I'm doing is changing `:content_type` to `:mimeType` when
creating a datastream.

I've confirmed that this works locally.
I've attached a screenshot of a Fedora object.
I'm going to self merge this, please use `:mimeType` when creating the derivative datastreams.

![screen shot 2018-04-03 at 4 36 39 pm](https://user-images.githubusercontent.com/8731/38274671-6d5946b0-375d-11e8-97d7-39bf93424a61.png)
