### PR TITLE
Don't delete failed jobs after Worker.max_attempts

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,3 +1,6 @@
 require 'nypl_log_formatter'
 
 Delayed::Worker.logger =  NyplLogFormatter.new(STDOUT)
+
+# The default is true
+Delayed::Worker.destroy_failed_jobs = false


### PR DESCRIPTION
Hey @emu47 

I was having trouble diagnosing why a job was failing and realized that `delayed_job`
deletes rows from the `delayed_jobs`after 25 attempts.

I _thinnnnnnkkkk_ it would be a good idea to keep them around.
Take a tour of the other config options towards the [bottom of the readme](https://github.com/collectiveidea/delayed_job/blob/c7a42fb78dc538de46024eb36b31e72916ff21a0/README.md) and let me know if you think we should fiddle with anything else.
