### PR TITLE
Change flag that derermines when to send checksums to Fedora

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ MMS_URL="http://localhost:3000"
 MMS_BASIC_USERNAME=admin
 MMS_BASIC_PASSWORD=password
 
+# Isilon must be mounted to the fedora/image-resolver machine, otherwise we get a checksum mismatch
+# This variable must be PRESENT (it doesn't matter its value) to tell fedora the checksum (and make it do the check)
+SEND_CHECKSUMS_TO_FEDORA=true
+
 # ONLY USED IN PRODUCTION
 SECRET_KEY_BASE=[OUTPUT OF `rake secret`]
 RAILS_ENV=production

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -55,7 +55,7 @@ IngestJob = Struct.new(:ingest_request_id) do
         # }
         if file_label != 'Unknown'
           datastream_options = {pid: pid, dsid: file_label, content: nil, controlGroup: 'E', mimeType: mime_type, checksumType: 'MD5', dsLocation: 'http://local.fedora.server/resolver/' + file_uuid, dsLabel: file_label + ' for this object', altIds: permalinks}
-          datastream_options.merge!({checksum: checksum}) if Rails.env.production?
+          datastream_options.merge!({checksum: checksum}) if ENV['SEND_CHECKSUMS_TO_FEDORA'].present?
           fedora_client.repository.add_datastream(datastream_options)
         end
 


### PR DESCRIPTION
Hey Kris

I ran into an issue today.
All of our environments run as `RAILS_ENV=production`, which is fine.
I think it's a little more 12-factory-ish to have development (for hot reloading) and production mode for deployment and all options are then configurable through environment variables. I'm happy with not cooking up custom RAILS_ENVs to match our deployment tiers.

Soooooo in our QA tier this was happening:

1.  `Rails.env.production? == true`
2.  We'd send the checksum along with the data stream.
3.  Adding the data stream threw an exception.
4.  I'd get an error that looks like the one below in in Fedora

How do you feel about making this it's own configuration option instead of tying it to `RAILS_ENV`?
Now - in our production ingestor envrionment we just set the `SEND_CHECKSUMS_TO_FEDORA` environment variable.

```
org.fcrepo.server.errors.GeneralException: Error getting http://local.fedora.server/resolver/22085C8A-8C10-11DD-9070-D8E39956CD08
	at org.fcrepo.server.storage.DefaultExternalContentManager.get(DefaultExternalContentManager.java:183)
	at org.fcrepo.server.storage.DefaultExternalContentManager.getFromWeb(DefaultExternalContentManager.java:332)
	at org.fcrepo.server.storage.DefaultExternalContentManager.getExternalContent(DefaultExternalContentManager.java:149)
	at org.fcrepo.server.storage.types.DatastreamReferencedContent.getContentStream(DatastreamReferencedContent.java:87)
	at org.fcrepo.server.storage.types.Datastream.getContentStreamForChecksum(Datastream.java:115)
	at org.fcrepo.server.storage.types.Datastream.computeChecksum(Datastream.java:183)
	at org.fcrepo.server.storage.types.Datastream.getChecksum(Datastream.java:135)
	at org.fcrepo.server.management.DefaultManagement.addDatastream(DefaultManagement.java:554)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.fcrepo.server.messaging.NotificationInvocationHandler.invoke(NotificationInvocationHandler.java:68)
	at com.sun.proxy.$Proxy0.addDatastream(Unknown Source)
	at org.fcrepo.server.management.ManagementModule.addDatastream(ManagementModule.java:227)
	at org.fcrepo.server.rest.DatastreamResource.addOrUpdateDatastream(DatastreamResource.java:467)
	at org.fcrepo.server.rest.DatastreamResource.addDatastream(DatastreamResource.java:358)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$ResponseOutInvoker._dispatch(AbstractResourceMethodDispatchProvider.java:175)
	at com.sun.jersey.server.impl.model.method.dispatch.ResourceJavaMethodDispatcher.dispatch(ResourceJavaMethodDispatcher.java:67)
	at com.sun.jersey.server.impl.uri.rules.HttpMethodRule.accept(HttpMethodRule.java:163)
	at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:111)
	at com.sun.jersey.server.impl.uri.rules.ResourceClassRule.accept(ResourceClassRule.java:71)
	at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:111)
	at com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:63)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:689)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:647)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:638)
	at com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:309)
	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:425)
	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:590)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:717)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:290)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
	at org.fcrepo.server.security.servletfilters.FilterRestApiFlash.doFilter(FilterRestApiFlash.java:79)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:235)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
	at org.fcrepo.server.security.jaas.AuthFilterJAAS.doFilter(AuthFilterJAAS.java:295)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:235)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:233)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:191)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:525)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:128)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:102)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:109)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:293)
	at org.apache.coyote.http11.Http11Processor.process(Http11Processor.java:849)
	at org.apache.coyote.http11.Http11Protocol$Http11ConnectionHandler.process(Http11Protocol.java:583)
	at org.apache.tomcat.util.net.JIoEndpoint$Worker.run(JIoEndpoint.java:454)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.net.UnknownHostException: local.fedora.server
```

