### PR TITLE
Throw exceptions if MMS response is >= 400

### DIFF
--- a/spec/models/mms_client_spec.rb
+++ b/spec/models/mms_client_spec.rb
@@ -11,28 +11,33 @@ RSpec.describe MMSClient, type: :model do
     end
 
     it 'makes a request to get MODS' do
-      expect(HTTP).to receive(:get).with('http://example.com/exports/mods/abc-123') { HTTP }
+      expect(HTTP).to receive(:get).with('http://example.com/exports/mods/abc-123', params: {}) { double(code: 200) }
       @mms_client.mods_for('abc-123')
     end
 
     it 'makes a request to get RELS-EXT' do
-      expect(HTTP).to receive(:get).with('http://example.com/exports/rels_ext/abc-123') { HTTP }
+      expect(HTTP).to receive(:get).with('http://example.com/exports/rels_ext/abc-123', params: {}) { double(code: 200) }
       @mms_client.rels_ext_for('abc-123')
     end
 
     it 'makes a request to get Rights' do
-      expect(HTTP).to receive(:get).with('http://example.com/exports/rights/abc-123') { HTTP }
+      expect(HTTP).to receive(:get).with('http://example.com/exports/rights/abc-123', params: {}) { double(code: 200) }
       @mms_client.rights_for('abc-123')
     end
 
     it 'makes a request to get Dublin Core' do
-      expect(HTTP).to receive(:get).with('http://example.com/exports/dc/abc-123') { HTTP }
+      expect(HTTP).to receive(:get).with('http://example.com/exports/dc/abc-123', params: {}) { double(code: 200) }
       @mms_client.dublin_core_for('abc-123')
     end
 
     it "makes a request to get an Item's Captures" do
-      expect(HTTP).to receive(:get).with('http://example.com/exports/get_captures/abc-123', params: {showAll: 'true'}) { HTTP }
+      expect(HTTP).to receive(:get).with('http://example.com/exports/get_captures/abc-123', params: {showAll: 'true'}) { double(code: 200) }
       @mms_client.captures_for_item('abc-123')
+    end
+
+    it "Throws exceptions on bad requests" do
+      expect(HTTP).to receive(:get).with('http://example.com/exports/dc/abc-123', params: {}) { double(code: 500) }
+      expect { @mms_client.dublin_core_for('abc-123') }.to raise_error(Exception)
     end
   end
 end


### PR DESCRIPTION
## Current Behavior (in master)

If `MMS_URL` env var is set to http://example.com...

1. We won't throw an exception.
2. `mms_client.captures_for_item(@ingest_request.uuid)` will be an empty Array so...
3.  Although we won't insert bad info to Fedora, the job will exit without error (which means the job will be deleted from the `delayed_jobs` table if MMS were down or an endpoint were throwing an error.

## Why Throw An Exception?

Throwing an exception if MMS returns an error code will:

1.  Halt execution of the delayed_job
2.  Guard against inserting an error page's HTML into Fedora
3.  Reque the job (if deleyed_job) is setup for that.