### PR TITLE
Stop sending checkum to Fedora for image derivatives

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,10 +28,6 @@ MMS_URL="http://localhost:3000"
 MMS_BASIC_USERNAME=admin
 MMS_BASIC_PASSWORD=password
 
-# Isilon must be mounted to the fedora/image-resolver machine, otherwise we get a checksum mismatch
-# This variable must be PRESENT (it doesn't matter its value) to tell fedora the checksum (and make it do the check)
-SEND_CHECKSUMS_TO_FEDORA=true
-
 # ONLY USED IN PRODUCTION
 SECRET_KEY_BASE=[OUTPUT OF `rake secret`]
 RAILS_ENV=production

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -42,7 +42,6 @@ IngestJob = Struct.new(:ingest_request_id) do
       image_filestore_entries.each do |f|
         file_uuid   = f.uuid
         file_label  = f.get_type(f.type)
-        checksum    = f.checksum
         file_name   = f.file_name
         extension   = file_name.split('.')[-1]
         mime_type   = f.get_mimetype(extension)
@@ -54,8 +53,7 @@ IngestJob = Struct.new(:ingest_request_id) do
         #   permalinks.add(permalink);
         # }
         if file_label != 'Unknown'
-          datastream_options = {pid: pid, dsid: file_label, content: nil, controlGroup: 'E', mimeType: mime_type, checksumType: 'MD5', dsLocation: 'http://local.fedora.server/resolver/' + file_uuid, dsLabel: file_label + ' for this object', altIds: permalinks}
-          datastream_options.merge!({checksum: checksum}) if ENV['SEND_CHECKSUMS_TO_FEDORA'].present?
+          datastream_options = {pid: pid, dsid: file_label, content: nil, controlGroup: 'E', mimeType: mime_type, checksumType: 'DISABLED', dsLocation: "http://local.fedora.server/resolver/#{file_uuid}" , dsLabel: file_label + ' for this object', altIds: permalinks}
           fedora_client.repository.add_datastream(datastream_options)
         end
 


### PR DESCRIPTION
We recently noticed that despite taking checksum as an argument,
the recent addDataStream() function:

 * sets `checksumType` to 'DISABLED'
 * doesn't try to send the checksum to Fedora.

source: https://github.com/NYPL/RepoAccess/blob/master/src/main/java/org/nypl/repo/access/fedora/FedoraAccessor.java#L142