### PR TITLE
Adds high level documentation of AWS/ECS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,6 @@ For insight into how CD works look at [.travis.yml](./.travis.yml) and the
 [provisioning/travis_ci_and_cd](./provisioning/travis_ci_and_cd) directory.
 The approach is inspired by [this blog post](https://dev.mikamai.com/2016/05/17/continuous-delivery-with-travis-and-ecs/) ([google cached version](https://webcache.googleusercontent.com/search?q=cache:NodZ-GZnk6YJ:https://dev.mikamai.com/2016/05/17/continuous-delivery-with-travis-and-ecs/+&cd=1&hl=en&ct=clnk&gl=us&client=firefox-b-1-ab)).
 
-## ECS Configuration
+## Amazon & ECS Deployment Configuration
 
-_this is mostly a stub until we actually deploy and can fill in more details_
-
-This app is meant to be deployed on ECS.
-
-We should create 2 task definitions.
-One for the web app, the second will be for a worker.
-The worker nodes' entry points should be overwritten to `["/home/app/fedora_ingest_rails/bin/delayed_job", "run"]`.
-
-The cluster should have 2 services.
-One for running the web application with a desired count of 1.
-The second "worker" service with a multiple "desired count" for  "worker" nodes.
+See [Amazon And ECS](./documentation/amazon-and-ecs.md).

--- a/documentation/amazon-and-ecs.md
+++ b/documentation/amazon-and-ecs.md
@@ -1,0 +1,81 @@
+# Amazon & ECS Deployment Configuration
+
+_This documentation is could be a rough guide for people looking to deploy web applications, with workers, on ECS.
+It's not an exhaustive document of AWS resource settings & names, that would get out of date fast._
+
+This application has 2 parts.
+
+1. Web app/API containers that receive requests and insert records into the `delayed_jobs` table.
+2. Worker containers to work the delayed_jobs.
+
+To allow either to scale independently, we:
+
+* Create 2 Task Definitions (One for the web app(s), the second will be for the worker(s))
+* The cluster is composed of 2 services.
+  * One for running the web application.
+  * The second, for the workers.
+
+This allows us to dial up or down each service's [desired count](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) depending on load/need.
+
+## Application Load Balancer
+
+Our EC2 instances are on a private network, but we handle web requests right?
+That's why we need a load balancer. The load balancer is internet facing and
+sends traffic to our machines on a private network. We need it to be an Application
+Load Balancer to be able to do the port mapping required to handle multiple web applications running on
+the same EC2 instance.
+
+* Name should be `fedora-ingest-rails-[tier]`.
+* It should be on a public subnet.
+* It should have a security group named `fedora-ingest-rails-[tier]-loadbalancer`.
+ * The security group should have 2 inbound rules that allow TCP (port 80) traffic from our internal IPs & VPN. (two broad CIDR blocks)
+
+## Cluster
+
+* Name should be `fedora-ingest-rails-[tier]`.
+* It should be on a private subnet.
+* It should be in a security group named `fedora-ingest-rails-ecs-cluster-[tier]`.
+  * That VPC can allow SSH from our internal network.
+  * It should allow TCP on ports (0-65535) from the security group of the load balancer. (this is for dynamic port binding see above)
+
+## Web Application
+
+### Task Definition
+
+* Name should be `fedora-ingest-rails-web-application-[tier]`
+* It should be given the task execution and task roles required to get its job done.
+* Its container should have the name `fedora-ingest-rails-web-[tier]`
+ * It should map container port 80 to host port 0. (When a container comes up it will expose its port 80 to an ephemeral port on the host but the Load Balancer sends traffic to the host's ephemeral port)
+ * There's no need to overwrite the `Entry point` since this [Dockerfile's](../Dockerfile) default `CMD` starts the web app.
+
+### Service
+
+Since it's a big-ish deal if we have no web apps running we should always have one up.
+An example of a service configuration that would ensure that is:
+
+* Number of Tasks: 2
+* Minimum Healthy Percent: 50
+* Maximum percent: 100
+
+When you create a service you'll be given a chance to:
+
+* Set the load balancer to the Application Load Balancer created in the first step.
+* Add the Task Definition's container to the load balancer.
+
+## Worker
+
+### Task Definition
+
+* Name should be `fedora-ingest-rails-worker-[tier]`.
+* It should be given the task execution and task roles required to get its job done.
+* Its container should have the name `fedora-ingest-rails-worker-[tier]`
+  * Since this is based on the same docker image as the web app, but doesn't run the web app,
+  its `Entry point` should be overwritten to `/home/app/fedora_ingest_rails/bin/delayed_job, run`
+
+### Service
+
+To prevent zero workers from running you can also configure the service to look like:
+
+* Number of Tasks: `[Whatever is appropriate]`
+* Minimum Healthy Percent: 50
+* Maximum percent: 100

--- a/documentation/amazon-and-ecs.md
+++ b/documentation/amazon-and-ecs.md
@@ -1,6 +1,6 @@
 # Amazon & ECS Deployment Configuration
 
-_This documentation is could be a rough guide for people looking to deploy web applications, with workers, on ECS.
+_This documentation is a rough guide for people looking to deploy web applications, with workers, on ECS.
 It's not an exhaustive document of AWS resource settings & names, that would get out of date fast._
 
 This application has 2 parts.
@@ -36,7 +36,7 @@ the same EC2 instance.
 * It should be on a private subnet.
 * It should be in a security group named `fedora-ingest-rails-ecs-cluster-[tier]`.
   * That VPC can allow SSH from our internal network.
-  * It should allow TCP on ports (0-65535) from the security group of the load balancer. (this is for dynamic port binding see above)
+  * It should allow TCP on all ports (0-65535) from the security group of the load balancer. (this is for dynamic port binding see above)
 
 ## Web Application
 


### PR DESCRIPTION
Hey @emu47 & @capdeploy 

This isn't a code change. I'm just looking for a few eyeballs to help review a VERY high level writeup of how this is wired-together in ECS. It doesn't talk about resource names directly because that would get out of date fast. 

It's just a guidepost for other folks who either:

1.  Want to deploy another web app + workers to ECS.
2.  May have to repair / extend / rebuild this app in the future.
