### PR TITLE
Add an endpoint to present information about state of jobs & ingests

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,0 +1,17 @@
+class StatsController < ApplicationController
+  def show
+    # Delayed::Job Related
+    workable_job_arel = Delayed::Job.where(last_error: nil)
+    @errored_jobs_count = Delayed::Job.where.not(last_error: nil).count
+    @workable_jobs_count = workable_job_arel.count
+    @total_jobs_count = Delayed::Job.count
+    @oldest_workable_job = workable_job_arel.order('created_at ASC').first
+
+    # IngestRequest Related
+    @total_ingested_count = IngestRequest.ingested.count
+    @total_pending_ingest_count = IngestRequest.pending_ingest.count
+    @total_ingest_requests_count = IngestRequest.count
+    @oldest_not_ingested = IngestRequest.pending_ingest.order('created_at ASC').first
+    @last_ingested = IngestRequest.ingested.last
+  end
+end

--- a/app/views/stats/show.json.jbuilder
+++ b/app/views/stats/show.json.jbuilder
@@ -1,0 +1,14 @@
+json.delayedJobs do
+  json.totalJobsCount @total_jobs_count
+  json.workableJobsCount @workable_jobs_count
+  json.erroredJobsCount @errored_jobs_count
+  json.oldestWorkableJob @oldest_workable_job
+end
+
+json.IngestRequests do
+  json.ingestedCount @total_ingested_count
+  json.pendingIngestCount @total_pending_ingest_count
+  json.totalIngestCount @total_ingest_requests_count
+  json.oldestNotIngested @oldest_not_ingested
+  json.lastIngested @last_ingested
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
    resources :ingest_requests, only: [:create], defaults: {format: :json}
    resources :ingest_history, only: [:show], defaults: {format: :json}
+   resource :stats, only: [:show], defaults: {format: :json}
 end


### PR DESCRIPTION
Heyooooo.

There are a few key numbers that I'm interested in.
Mostly - how old is the oldest delayed job, how many delayed jobs are pending, etc.
Youuu knowww - to get a feel for how big the service's backlog of work is, and its general state.

I'm not keen on SSHing onto an EC2 machine then `docker exec`ing into a running instance just to connect to the database. Is this crazy?
I could see us adding things like an average delta of time between request to ingest and hitting Fedora.

Here's an example request and its response:

### Request
`curl http://localhost:3000/stats | json_pp | pbcopy`

### Response

```json
{
   "IngestRequests" : {
      "ingestedCount" : 1,
      "oldestNotIngested" : {
         "id" : 15333,
         "created_at" : "2018-04-24T15:40:32.958Z",
         "ingested_at" : null,
         "updated_at" : "2018-04-24T15:40:32.958Z",
         "uuid" : "abc-123"
      },
      "totalIngestCount" : 3,
      "pendingIngestCount" : 2,
      "lastIngested" : {
         "id" : 15332,
         "updated_at" : "2018-04-17T17:59:26.991Z",
         "uuid" : "654ddd30-c532-012f-3bce-58d385a7bc34",
         "ingested_at" : "2018-04-17T17:59:26.990Z",
         "created_at" : "2018-04-17T17:56:25.801Z"
      }
   },
   "delayedJobs" : {
      "oldestWorkableJob" : {
         "updated_at" : "2018-04-24T15:56:54.408Z",
         "queue" : null,
         "created_at" : "2018-04-24T15:56:54.408Z",
         "locked_by" : null,
         "handler" : "--- !ruby/struct:IngestJob\ningest_request_id: 15334\n",
         "last_error" : null,
         "run_at" : "2018-04-24T15:56:54.407Z",
         "id" : 15335,
         "attempts" : 0,
         "priority" : 0,
         "locked_at" : null,
         "failed_at" : null
      },
      "totalJobsCount" : 2,
      "erroredJobsCount" : 1,
      "workableJobsCount" : 1
   }
}
```

Feel free to ignore this if you think I'm overreacting and overcompensating for my control issues.
Also - since I'm out of the office **You both have free rein to rename any of the variables or JSON keys**.
