### PR TITLE
Log Rubydora errors to NYPL-formatted stdout

### DIFF
--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+Rubydora.logger = NyplLogFormatter.new(STDOUT)
 
 IngestJob = Struct.new(:ingest_request_id) do
   def perform


### PR DESCRIPTION
## Currently

If Fedora throws a server-side exception we get an error in the log that looks like:

```json
{
   "timestamp" : "2018-04-26T12:30:52.345-0400",
   "level" : "ERROR",
   "message" : "2018-04-26T12:30:52-0400: [Worker(host:Stephens-MacBook-Pro-4.local pid:6357)] Job IngestJob (id=15336) FAILED (8 prior attempts) with Rubydora::FedoraInvalidRequest: See logger for details"
}
```
## In This Branch

It will now include Fedora's stacktrace, like this:

```json
{
   "message" : "javax.ws.rs.WebApplicationException: org.fcrepo.server.errors.GeneralException: Unknown checksum algorithm specified: MD5x\n\tat org.fcrepo.server.rest.BaseRestResource.handleException(BaseRestResource.java:168)\n\tat org.fcrepo.server.rest.DatastreamResource.addOrUpdateDatastream(DatastreamResource.java:583)\n\tat org.fcrepo.server.rest.DatastreamResource.addDatastream(DatastreamResource.java:358)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$ResponseOutInvoker._dispatch(AbstractResourceMethodDispatchProvider.java:175)\n\tat com.sun.jersey.server.impl.model.method.dispatch.ResourceJavaMethodDispatcher.dispatch(ResourceJavaMethodDispatcher.java:67)\n\tat com.sun.jersey.server.impl.uri.rules.HttpMethodRule.accept(HttpMethodRule.java:163)\n\tat com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:111)\n\tat com.sun.jersey.server.impl.uri.rules.ResourceClassRule.accept(ResourceClassRule.java:71)\n\tat com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:111)\n\tat com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:63)\n\tat com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:689)\n\tat com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:647)\n\tat com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:638)\n\tat com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:309)\n\tat com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:425)\n\tat com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:590)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:717)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:290)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)\n\tat org.fcrepo.server.security.servletfilters.FilterRestApiFlash.doFilter(FilterRestApiFlash.java:79)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:235)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)\n\tat org.fcrepo.server.security.jaas.AuthFilterJAAS.doFilter(AuthFilterJAAS.java:295)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:235)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)\n\tat org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:233)\n\tat org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:191)\n\tat org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:525)\n\tat org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:128)\n\tat org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:102)\n\tat org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:109)\n\tat org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:293)\n\tat org.apache.coyote.http11.Http11Processor.process(Http11Processor.java:849)\n\tat org.apache.coyote.http11.Http11Protocol$Http11ConnectionHandler.process(Http11Protocol.java:583)\n\tat org.apache.tomcat.util.net.JIoEndpoint$Worker.run(JIoEndpoint.java:454)\n\tat java.lang.Thread.run(Thread.java:748)\nCaused by: org.fcrepo.server.errors.GeneralException: Unknown checksum algorithm specified: MD5x\n\tat org.fcrepo.server.storage.types.Datastream.validateChecksumType(Datastream.java:251)\n\tat org.fcrepo.server.management.DefaultManagement.modifyDatastreamByValue(DefaultManagement.java:902)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.fcrepo.server.messaging.NotificationInvocationHandler.invoke(NotificationInvocationHandler.java:68)\n\tat com.sun.proxy.$Proxy0.modifyDatastreamByValue(Unknown Source)\n\tat org.fcrepo.server.management.ManagementModule.modifyDatastreamByValue(ManagementModule.java:407)\n\tat org.fcrepo.server.rest.DatastreamResource.addOrUpdateDatastream(DatastreamResource.java:502)\n\t... 38 more\n",
   "timestamp" : "2018-04-26T12:34:15.542-0400",
   "level" : "ERROR"
}
```
## How to reproduce

Configure your localhost (pointing to valid postgres, MMS, MySQL, and Fedora instances) but, in calls to `fedora_client.repository.add_datastream`, temporarily change the `checksumType` to 'iamnot-md5'.

Then , in a rails console:

```
# create an IngestRequest
IngestRequest.create uuid: '654ddd30-c532-012f-3bce-58d385a7bc34'

# run its Delayed::Job
Delayed::Worker.new.run(Delayed::Job.last)
```

In `master` you'll get the exception telling  you to look at the log.
In this branch you'll get the additional log message (level `ERROR`) providing the Fedora stacktrace.
