### PR TITLE
Make one deterministic call to LinkMinter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,6 @@ MMS_BASIC_USERNAME=admin
 MMS_BASIC_PASSWORD=password
 
 # Used to connect to link minter service
-LINK_MINTER_URL=http://localhost:8081/link-admin/records
-LINK_LOOKUP_URL=http://localhost:8081/link-admin/lookup
 LINK_USERNAME=link
 LINK_PASSWORD=link
 LINK_BASE_URL=http://localhost:8081

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -56,7 +56,7 @@ IngestJob = Struct.new(:ingest_request_id) do
         mime_type   = f.get_mimetype(extension)
         permalinks  = []
         if file_label == "MASTER_IMAGE" && release_master
-          permalink = PermalinkClient.new.fetch_or_mint_permalink("#{ENV['FEDORA_URL']}/objects/#{pid}/datastreams/MASTER_IMAGE/content")
+          permalink = PermalinkClient.new(uuid: file_uuid).fetch_or_mint_permalink("#{ENV['FEDORA_URL']}/objects/#{pid}/datastreams/MASTER_IMAGE/content")
           permalinks << permalink if permalink.present?
         end
         if file_label != 'Unknown'

--- a/app/models/permalink_client.rb
+++ b/app/models/permalink_client.rb
@@ -4,60 +4,43 @@ require 'net/http/digest_auth'
 
 class PermalinkClient
   def initialize(options = {})
+    @uuid = options[:uuid]
     @base_links_url = ENV['LINK_BASE_URL']
-    @lookup_url = ENV['LINK_LOOKUP_URL']
-    @minter_url = ENV['LINK_MINTER_URL']
     @basic_username = ENV['LINK_USERNAME']
     @basic_password = ENV['LINK_PASSWORD']
+    @logger = NyplLogFormatter.new(STDOUT)
   end
-  
+
   def fetch_or_mint_permalink(not_permalink_string)
-    link_id = fetch_permalink(not_permalink_string) || mint_permalink(not_permalink_string)
-    @base_links_url + link_id
-  end
-
-  private
-  
-  def fetch_permalink(not_permalink_string)
-    uri = URI.parse "#{@lookup_url}?url=#{not_permalink_string}"
-    res = authed_request(uri)
-    
-    if res.code.eql? "200"
-      a = JSON.parse(res.body)
-      if a["linkRecord"].is_a?(Hash)
-        return a["linkRecord"]["linkID"]
-      elsif a["linkRecord"].is_a?(Array)
-        # link minter service does not control for uniqueness of urls.
-        return a["linkRecord"][0]["linkID"].to_s
-      end
-    else
-      throw RuntimeError.new("Error fetching link from link minter. #{res.code}: #{res.body}")
-    end
-  end
-
-  def mint_permalink(not_permalink_string)
-    uri = URI.parse "#{@minter_url}?url=#{not_permalink_string}&username=link_client"
+    # `/record` will find or create a shortened link.
+    # There's no need to manually look it up.
+    # The providing the same uuid for a given URL makes the shortened URL returned deterministically the same.
+    uri = URI.parse "#{@base_links_url}/link-admin/record?url=#{not_permalink_string}&username=fedora_ingest_rails&redirect=false&uuid=#{@uuid}"
     res = authed_request(uri,'POST')
     if res.code.eql? "201"
-      return res.body.to_s
+      @logger.info("Found or created permalink", url: not_permalink_string, mintedCode: res.body.to_s)
+      return "#{@base_links_url}/#{res.body.to_s}"
     else
       throw RuntimeError.new("Error minting link from link minter. #{res.code}: #{res.body}")
     end
+
   end
-  
+
+  private
+
   def authed_request(uri, http_verb='GET')
     uri.user = @basic_username
     uri.password = @basic_password
-  
+
     h = Net::HTTP.new uri.host, uri.port
     req = Net::HTTP::Get.new uri.request_uri
     res = h.request req
-    
+
     digest_auth = Net::HTTP::DigestAuth.new
     auth = digest_auth.auth_header uri, res['www-authenticate'], http_verb # 'GET' or 'POST'
     req = http_verb == 'POST' ? Net::HTTP::Post.new(uri.request_uri) : Net::HTTP::Get.new(uri.request_uri)
     req.add_field 'Authorization', auth
-    
+
     h.request req
   end
 end


### PR DESCRIPTION
Now we're going to call the [/record endpoint](https://github.com/NYPL/link/blob/master/link-admin/src/main/java/org/nypl/repository/link_admin/LinkAdminResource.java#L187) of the link minter, not `/records`.  **`/record` will do find-or-create for us.**

The `uuid` parameter helps ensures a deterministically find-or-create logic.

For example:

Asking for a shortened link of "http://example.com", with a uuid of "abc-123", 4 times
will always return the same link code. If the 5th time you ask, but with a uuid of "xyz-000"
you will get a new link code.

In addition we are passing `redirect=false` which ensures our links are proxied, not redirected to.