### PR TITLE
Use docker-compose to run locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,11 +9,11 @@
 
 /node_modules
 /yarn-error.log
-
+/database-data/postgres
 .byebug_history
 
 # Let's not bake secrets into our Docker images
-.env
+.env.docker
 
 # This messes with how phusion/passenger-ruby wants to install gems
 .ruby-version

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,7 @@
 .byebug_history
 
 # Let's not bake secrets into our Docker images
-.env.docker
+.env
 
 # This messes with how phusion/passenger-ruby wants to install gems
 .ruby-version

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 /node_modules
 /yarn-error.log
 /database-data/postgres
+/database-data/mysql
 .byebug_history
 
 # Let's not bake secrets into our Docker images

--- a/.env.example
+++ b/.env.example
@@ -1,48 +1,47 @@
-# IMAGES FILESTORE INFO
-IMAGE_FILESTORE_DATABASE_NAME=images_filestore
-IMAGE_FILESTORE_DATABASE_USER=root
+#### SERVICES INCLUDED IN DOCKERIZED STACK
 
-# defaults to 'localhost' in database.yml
-IMAGE_FILESTORE_DATABASE_HOST='some.domain.name'
+# There's little chance you'll have to change these credentials because these values
+# are hard-wired to work out-of-the-box on the dockerized stack (see docker-compose.yml)
 
-# defaults to nil in database.yml
-IMAGE_FILESTORE_DATABASE_PASSWORD=somepassword
-
-# AMI FILESTORE INFO
-AMI_FILESTORE_DATABASE_NAME=ami_filestore
-AMI_FILESTORE_DATABASE_USER=root
-
-# defaults to 'localhost' in database.yml
-AMI_FILESTORE_DATABASE_HOST='some.domain.name'
-
-# defaults to nil in database.yml
-AMI_FILESTORE_DATABASE_PASSWORD=somepassword
-
-# Used to connect to Fedora
+# Fedora
 FEDORA_USERNAME=fedoraAdmin
 FEDORA_PASSWORD=password
-FEDORA_URL=http://localhost:8080/fedora
+FEDORA_URL=http://fedora:8080/fedora
 
-# Used to connect to MMS
-MMS_URL="http://localhost:3000"
+#### REMOTE SERVICES
+
+# Image Filestore
+IMAGE_FILESTORE_DATABASE_HOST=[some.domain.name]
+IMAGE_FILESTORE_DATABASE_NAME=[database-name]
+IMAGE_FILESTORE_DATABASE_USER=[some-user-name]
+IMAGE_FILESTORE_DATABASE_PASSWORD=[some-password]
+
+# Audio & Moving Image Filestore
+AMI_FILESTORE_DATABASE_HOST=[some.domain.name]
+AMI_FILESTORE_DATABASE_NAME=[database-name]
+AMI_FILESTORE_DATABASE_USER=[some-user-name]
+AMI_FILESTORE_DATABASE_PASSWORD=[some-password]
+
+# MMS API (host.docker.internal means your HOST machine, localhost)
+MMS_URL="http://host.docker.internal:3000"
 MMS_BASIC_USERNAME=admin
 MMS_BASIC_PASSWORD=password
 
-# Used to connect to link minter service
+# Solr Instance that holds relationship information
+RELS_EXT_SOLR_URL=http://example.com:8080/solr-3.5/repoRels
+RELS_EXT_USERNAME=username
+RELS_EXT_PASSWORD=password
+
+# Link minter service
 LINK_USERNAME=link
 LINK_PASSWORD=link
 LINK_CREATE_BASE_URL=http://localhost:8081
 LINK_PUBLIC_BASE_URL=http://localhost:8081
 
-# REPO-RELS SOLR INFO
-RELS_EXT_SOLR_URL=http://example.com:8080/solr-3.5/repoRels
-RELS_EXT_USERNAME=username
-RELS_EXT_PASSWORD=password
+#### VARIABLES USED FOR LOCAL DEVELOPMENT
 
-# ONLY USED IN PRODUCTION
-SECRET_KEY_BASE=[OUTPUT OF `rake secret`]
-RAILS_ENV=production
-FEDORA_INGEST_RAILS_DATABASE_HOST="dbserver.example.com"
-FEDORA_INGEST_RAILS_DATABASE_PASSWORD="something-very-secret"
+# You shouldn't want/have to edit these
 
-#
+INGESTOR_TEST_DATABASE_HOST=postgres
+PASSENGER_APP_ENV=development
+RAILS_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -2,25 +2,26 @@
 
 # There's little chance you'll have to change these credentials because these values
 # are hard-wired to work out-of-the-box on the dockerized stack (see docker-compose.yml)
+# Only change these if you want to connect to other instances.
 
 # Fedora
 FEDORA_USERNAME=fedoraAdmin
 FEDORA_PASSWORD=password
 FEDORA_URL=http://fedora:8080/fedora
 
-#### REMOTE SERVICES
-
 # Image Filestore
-IMAGE_FILESTORE_DATABASE_HOST=[some.domain.name]
-IMAGE_FILESTORE_DATABASE_NAME=[database-name]
-IMAGE_FILESTORE_DATABASE_USER=[some-user-name]
-IMAGE_FILESTORE_DATABASE_PASSWORD=[some-password]
+IMAGE_FILESTORE_DATABASE_HOST=filestore-db
+IMAGE_FILESTORE_DATABASE_NAME=image_filestore_development
+IMAGE_FILESTORE_DATABASE_USER=root
+IMAGE_FILESTORE_DATABASE_PASSWORD=mysqlpassword
 
 # Audio & Moving Image Filestore
-AMI_FILESTORE_DATABASE_HOST=[some.domain.name]
-AMI_FILESTORE_DATABASE_NAME=[database-name]
-AMI_FILESTORE_DATABASE_USER=[some-user-name]
-AMI_FILESTORE_DATABASE_PASSWORD=[some-password]
+AMI_FILESTORE_DATABASE_HOST=filestore-db
+AMI_FILESTORE_DATABASE_NAME=ami_filestore_development
+AMI_FILESTORE_DATABASE_USER=root
+AMI_FILESTORE_DATABASE_PASSWORD=mysqlpassword
+
+#### REMOTE SERVICES
 
 # MMS API (host.docker.internal means your HOST machine, localhost)
 MMS_URL="http://host.docker.internal:3000"

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,10 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
-/database-data/postgres
-/database-data/mysql
+/database-data/postgres/*
+!/database-data/postgres/.keep
+/database-data/mysql/*
+!/database-data/mysql/.keep
 /node_modules
 /yarn-error.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 !/log/.keep
 !/tmp/.keep
 /database-data/postgres
+/database-data/mysql
 /node_modules
 /yarn-error.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 
 .byebug_history
 .env
+.env.docker

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@
 
 .byebug_history
 .env
-.env.docker

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
-
+/database-data/postgres
 /node_modules
 /yarn-error.log
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby25:0.9.32
+FROM phusion/passenger-ruby25:0.9.32 AS production
 
 # Set correct environment variables.
 ENV HOME /root
@@ -31,3 +31,7 @@ RUN rm -f /etc/service/nginx/down
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+FROM production AS development
+
+run cd /home/app/fedora_ingest_rails && bundle --with test development

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,3 +35,5 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 FROM production AS development
 
 run cd /home/app/fedora_ingest_rails && bundle --with test development
+# It will be linked from localhost
+run rm -rf /home/app/fedora_ingest_rails/*

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ group :test do
 end
 
 group :development, :test do
-  gem 'dotenv-rails', '~> 2.2', '>= 2.2.1'
   gem 'puma', '~> 3.7'
   gem 'factory_bot_rails', '~> 4.8', '>= 4.8.2'
   gem 'rspec-rails', '~> 3.7', '>= 3.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,10 +58,6 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.2.1)
-    dotenv-rails (2.2.1)
-      dotenv (= 2.2.1)
-      railties (>= 3.2, < 5.2)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubi (1.7.1)
@@ -251,7 +247,6 @@ PLATFORMS
 DEPENDENCIES
   daemons (~> 1.2, >= 1.2.6)
   delayed_job_active_record (~> 4.1, >= 4.1.2)
-  dotenv-rails (~> 2.2, >= 2.2.1)
   factory_bot_rails (~> 4.8, >= 4.8.2)
   http (~> 3.0)
   jbuilder (~> 2.5)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Forget Docker is there.**
 
 1. Clone this repo.
 1. Clone [NYPL/fedoracommons-3.4.2-dockerized](https://github.com/NYPL/fedoracommons-3.4.2-dockerized) & [NYPL/filestore_databases_docker](https://github.com/NYPL/filestore_databases_docker) in the directory above this. (make them siblings of this app)
-1. In this app's root directory `./.env.example` to `./.env` and fill it out.
+1. In this app's root directory `cp ./.env.example ./.env` and fill it out.
 1. Ensure MMS is running on port 3000
 1. `docker-compose up --scale worker=2`
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,44 @@ Then (via DelayedJob):
 * Iterates through those UUIDS and asks MMS for the latest information.
   - Asks other services (like Filestore DB) for more information about the item.
 
-* Turns around and posts that information to Fedora.
+* Turns around and posts that information to Fedora & RELS-EXT Solr
 
 This decouples MMS from direct communication with Fedora in the event of Fedora API changes or downtime.
 
-## Installing
+## Installing & Running
 
-### Creating and boostrapping Databases
+This application uses [docker-compose.yml](./docker-compose.yml) to run _most_ of what it needs.
+As time goes on, we're trying to Dockerize more dependencies and have `docker-compose` be
+one-stop shopping for running locally. **You can edit code as on your machine and expect it to hot-reload like you usually would.
+Forget Docker is there.**
+
+1. Clone [NYPL/fedoracommons-3.4.2-dockerized](https://github.com/NYPL/fedoracommons-3.4.2-dockerized) in the directory above this.
+1. In this app's root directory `./.env.example` to `./.env` and fill it out.
+1. Ensure MMS is running on port 3000
+1. `docker-compose up --scale worker=2`
+
+### What Does Compose Spin Up?
+
+It brings up the following services:
+
+#### The App Itself
+
+The app reachable at http://localhost:3000.
+It also spins up 2 workers.
+
+#### PostgreSQL
+
+The app's database persists in `./database-data/postgres` of _your_ machine.
+
+#### Fedora
+
+Our [dockerized Fedora instance](https://github.com/NYPL/fedoracommons-3.4.2-dockerized) reachable at http://localhost:8080.
+
+## Testing
+
+`docker run --workdir /home/app/fedora_ingest_rails --env-file .env fedora_ingest_rails_webapp /usr/bin/bundle exec rspec`
+
+### Creating and Bootstrapping Databases
 
 In addition to its own database, this application communicates to
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ As time goes on, we're trying to Dockerize more dependencies and have `docker-co
 one-stop shopping for running locally. **You can edit code as on your machine and expect it to hot-reload like you usually would.
 Forget Docker is there.**
 
-1. Clone [NYPL/fedoracommons-3.4.2-dockerized](https://github.com/NYPL/fedoracommons-3.4.2-dockerized) in the directory above this.
+1. Clone this repo.
+1. Clone [NYPL/fedoracommons-3.4.2-dockerized](https://github.com/NYPL/fedoracommons-3.4.2-dockerized) & [NYPL/filestore_databases_docker](https://github.com/NYPL/filestore_databases_docker) in the directory above this. (make them siblings of this app)
 1. In this app's root directory `./.env.example` to `./.env` and fill it out.
 1. Ensure MMS is running on port 3000
 1. `docker-compose up --scale worker=2`

--- a/README.md
+++ b/README.md
@@ -120,4 +120,5 @@ See [Amazon And ECS](./documentation/amazon-and-ecs.md).
 
 ## Debugging
 
-See [Debugging](./documentation/debugging.md).
+You may want to start a rails console or hit an endpoint for debugging purposes.  
+See the [debugging documentation](./documentation/debugging.md).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This is a Rails port of the Java application [FedoraIngest](https://github.com/NYPL/FedoraIngest/blob/master/README.md).
 
-It an endpoint that [MMS](https://bitbucket.org/NYPL/mms/) hits (with
+It has an endpoint that [MMS](https://bitbucket.org/NYPL/mms/) hits (with
 an items' UUIDs as a parameter). It records the UUID in an internal database.
 
 Then (via DelayedJob):
@@ -23,14 +23,14 @@ This decouples MMS from direct communication with Fedora in the event of Fedora 
 
 ## Installing & Running
 
-This application uses [docker-compose.yml](./docker-compose.yml) to run _most_ of what it needs.
-As time goes on, we're trying to Dockerize more dependencies and have `docker-compose` be
+This application uses [docker-compose.yml](./docker-compose.yml) to for _most_ of what it needs.
+As time goes on, we'll Dockerize more dependencies and have `docker-compose` be
 one-stop shopping for running locally. **You can edit code as on your machine and expect it to hot-reload like you usually would.
 Forget Docker is there.**
 
 1. Clone this repo.
 1. Clone [NYPL/fedoracommons-3.4.2-dockerized](https://github.com/NYPL/fedoracommons-3.4.2-dockerized) & [NYPL/filestore_databases_docker](https://github.com/NYPL/filestore_databases_docker) in the directory above this. (make them siblings of this app)
-1. In this app's root directory `cp ./.env.example ./.env` and fill it out.
+1. In this app's root directory `cp ./.env.example ./.env` and fill it out. (See directions in `.env.example`)
 1. Ensure MMS is running on port 3000
 1. `docker-compose up --scale worker=2`
 
@@ -53,12 +53,23 @@ Our [dockerized Fedora instance](https://github.com/NYPL/fedoracommons-3.4.2-doc
 
 #### Filestore Databases
 
+The app's database persists in `./database-data/postgres` of _your_ machine.
+
 It brings up the moving & still image MySQL filestore databases.
-If you want to connect to the real thing, than change your .env file.
+Change your `.env` file if you want to connect to a remote filestore.
 
 ## Testing
 
-`docker run --workdir /home/app/fedora_ingest_rails --env-file .env fedora_ingest_rails_webapp bundle exec rspec`
+Running tests is a little tedious, we should look into a way to run this
+in one shot from the host OS.
+
+With the whole stack running...
+
+1. Get the CONTAINER ID of fedora_ingest_rails_webapp with `docker ps`
+1. `docker exec -it container_id /bin/bash`
+1. (inside container)`su app`
+1. `cd /home/app/fedora_ingest_rails/`
+1.  `RAILS_ENV=test bundle exec rspec`
 
 ## Git Workflow & Deployment
 

--- a/README.md
+++ b/README.md
@@ -50,51 +50,14 @@ The app's database persists in `./database-data/postgres` of _your_ machine.
 
 Our [dockerized Fedora instance](https://github.com/NYPL/fedoracommons-3.4.2-dockerized) reachable at http://localhost:8080.
 
+#### Filestore Databases
+
+It brings up the moving & still image MySQL filestore databases.
+If you want to connect to the real thing, than change your .env file.
+
 ## Testing
 
-`docker run --workdir /home/app/fedora_ingest_rails --env-file .env fedora_ingest_rails_webapp /usr/bin/bundle exec rspec`
-
-### Creating and Bootstrapping Databases
-
-In addition to its own database, this application communicates to
-
-* A MySQL database that stores the images that are in isilon.
-* A MySQL database that stores audio/videos that are in isilon.
-
-They are in different databases for historic reasons and one
-day, they should be combined.
-
-#### Bootstrapping the image filestore database
-
-1. Create MySQL Database
-  - `create database ami_filestore_development;`
-  - `create database ami_filestore_test;`
-  - `create database image_filestore_development;`
-  - `create database image_filestore_test;`
-
-2. Load its contents with a command like `mysql -uroot DBNAME < ./db/resources/image_filestore_schema.sql`
-
-#### Bootstrapping the AMI filestore database
-
-1. Create a MySQL database
-2. Load its contents with a command like `mysql -uroot DBNAME < ./db/resources/ami_filestore_schema.sql`
-
-### Setting Environment Variables
-
-Copy `./.env.example` to `./.env`.
-
-Fill it out with:
-
-* Credentials to the two databases mentioned above.
-* Host and credentials for making requests to MMS's API.
-* Host and credentials for connecting to Fedora.
-
-## Running Delayed Job
-
-The rails application accepts work by being hit by HTTP requests but
-does all its hard work in DelayedJob workers. This allows it to answer
-requests quickly while being horizontally scalable by spinning up
-additional workers.
+`docker run --workdir /home/app/fedora_ingest_rails --env-file .env fedora_ingest_rails_webapp bundle exec rspec`
 
 ## Git Workflow & Deployment
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,22 @@ As time goes on, we'll Dockerize more dependencies and have `docker-compose` be
 one-stop shopping for running locally. **You can edit code as on your machine and expect it to hot-reload like you usually would.
 Forget Docker is there.**
 
+### Setup
+
 1. Clone this repo.
 1. Clone [NYPL/fedoracommons-3.4.2-dockerized](https://github.com/NYPL/fedoracommons-3.4.2-dockerized) & [NYPL/filestore_databases_docker](https://github.com/NYPL/filestore_databases_docker) in the directory above this. (make them siblings of this app)
 1. In this app's root directory `cp ./.env.example ./.env` and fill it out. (See directions in `.env.example`)
-1. Ensure MMS is running on port 3000
-1. `docker-compose up --scale worker=2`
+
+#### Setting Up Databases (first run)
+
+1.  Run `docker-compose up filestore-db postgres`, wait, let the databases be created, and synched/mounted to ./database-data.
+The output will slow down after ~30 seconds.
+1.  Now, in another terminal run `docker-compose run webapp`, this will create the database and run the migrations.
+1.  Once the migrations end you can `crtl-z` and stop the services
+
+### Running
+
+`docker-compose up --scale worker=2`
 
 ### What Does Compose Spin Up?
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,9 @@ default: &default
 
 development:
   <<: *default
+  host: postgres
   database: fedora_ingest_rails_development
+  username: postgres
 
 image_filestore:
   adapter: mysql2
@@ -24,9 +26,13 @@ ami_filestore:
   username: <%= ENV.fetch("AMI_FILESTORE_DATABASE_USER") %>
   password: <%= ENV.fetch("AMI_FILESTORE_DATABASE_PASSWORD") {nil} %>
   reconnect: true
-  
+
 test:
   <<: *default
+  host: postgres
+  database: fedora_ingest_rails_test
+  username: postgres
+
   database: fedora_ingest_rails_test
 
 production:

--- a/config/database.yml
+++ b/config/database.yml
@@ -32,7 +32,7 @@ test:
   <<: *default
   host: <%= ENV.fetch('INGESTOR_TEST_DATABASE_HOST') { '127.0.0.1' } %>
   database: fedora_ingest_rails_test
-  username: <%= ENV.fetch('INGESTOR_TEST_DATABASE_USER') {'root'} %>
+  username: postgres
 
 production:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -29,10 +29,7 @@ ami_filestore:
 
 test:
   <<: *default
-  host: postgres
-  database: fedora_ingest_rails_test
-  username: postgres
-
+  host: <%= ENV.fetch('INGESTOR_TEST_DATABASE_HOST') { '127.0.0.1' } %>
   database: fedora_ingest_rails_test
 
 production:

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,10 +27,12 @@ ami_filestore:
   password: <%= ENV.fetch("AMI_FILESTORE_DATABASE_PASSWORD") {nil} %>
   reconnect: true
 
+# The ENV VARs are for Dockerized localhost, the default Procs are for Travis
 test:
   <<: *default
   host: <%= ENV.fetch('INGESTOR_TEST_DATABASE_HOST') { '127.0.0.1' } %>
   database: fedora_ingest_rails_test
+  username: <%= ENV.fetch('INGESTOR_TEST_DATABASE_USER') {'root'} %>
 
 production:
   <<: *default

--- a/db/resources/README.txt
+++ b/db/resources/README.txt
@@ -1,4 +1,1 @@
-These sql files aren't meant for production.
-They're just for development / test mode.
-In production, this app has no business building or manipulating
-the filestore DBs.
+This is only used by Travis for the test suite.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,13 @@ services:
       - ./.env.docker
     volumes:
       - '.:/home/app/fedora_ingest_rails'
+    depends_on:
+      - postgres
+    ports:
+      - '3000:80'
   postgres:
     image:  postgres:9.4.14
+    volumes:
+      - ./database-data/postgres:/var/lib/postgresql/data
+    ports:
+      - '5432'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     build:
       context: ../filestore_databases_docker
       dockerfile: Dockerfile
+    volumes:
+      - ./database-data/mysql:/var/lib/mysql
     ports:
       - '3306:3306'
   worker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,17 @@
-version: '3'
+version: '3.4'
 services:
   webapp:
     build:
       context: .
       dockerfile: Dockerfile
+      target: development
     env_file:
       - ./.env.docker
     volumes:
       - '.:/home/app/fedora_ingest_rails'
     depends_on:
       - postgres
+      - fedora
     ports:
       - '3000:80'
   postgres:
@@ -18,3 +20,9 @@ services:
       - ./database-data/postgres:/var/lib/postgresql/data
     ports:
       - '5432'
+  fedora:
+    build:
+      context: ../fedoracommons-3.4.2-dockerized
+      dockerfile: Dockerfile
+    ports:
+      - '8080:8080'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile
       target: development
     env_file:
-      - ./.env.docker
+      - ./.env
     volumes:
       - '.:/home/app/fedora_ingest_rails'
     ports:
@@ -20,7 +20,7 @@ services:
       dockerfile: Dockerfile
       target: development
     env_file:
-      - ./.env.docker
+      - ./.env
     volumes:
       - '.:/home/app/fedora_ingest_rails'
     entrypoint: /home/app/fedora_ingest_rails/bin/delayed_job run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - '.:/home/app/fedora_ingest_rails'
     ports:
-      - '3000:80'  
+      - '3001:80'  
     depends_on:
       - postgres
       - fedora

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,29 @@ services:
     depends_on:
       - postgres
       - fedora
+      - mysql
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    env_file:
+      - ./.env.docker
+    volumes:
+      - '.:/home/app/fedora_ingest_rails'
+    entrypoint: /home/app/fedora_ingest_rails/bin/delayed_job run
+    depends_on:
+      - postgres
+      - fedora
+      - mysql
+  mysql:
+    image: mysql:5.6
+    volumes:
+      - './database-data/mysql:/var/lib/mysql'
     ports:
-      - '3000:80'
+      - '3306'
+    environment:
+      - 'MYSQL_ALLOW_EMPTY_PASSWORD=yes'
   postgres:
     image:  postgres:9.4.14
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  webapp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - ./.env.docker
+    volumes:
+      - '.:/home/app/fedora_ingest_rails'
+  postgres:
+    image:  postgres:9.4.14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,10 @@ services:
     volumes:
       - '.:/home/app/fedora_ingest_rails'
     ports:
-      - '3001:80'  
+      - '3001:80'
     depends_on:
       - postgres
       - fedora
-      - mysql
   worker:
     build:
       context: .
@@ -28,15 +27,6 @@ services:
     depends_on:
       - postgres
       - fedora
-      - mysql
-  mysql:
-    image: mysql:5.6
-    volumes:
-      - './database-data/mysql:/var/lib/mysql'
-    ports:
-      - '3306'
-    environment:
-      - 'MYSQL_ALLOW_EMPTY_PASSWORD=yes'
   postgres:
     image:  postgres:9.4.14
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,13 @@ services:
     depends_on:
       - postgres
       - fedora
+      - filestore-db
+  filestore-db:
+    build:
+      context: ../filestore_databases_docker
+      dockerfile: Dockerfile
+    ports:
+      - '3306:3306'
   worker:
     build:
       context: .
@@ -27,6 +34,7 @@ services:
     depends_on:
       - postgres
       - fedora
+      - filestore-db
   postgres:
     image:  postgres:9.4.14
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - ./.env.docker
     volumes:
       - '.:/home/app/fedora_ingest_rails'
+    ports:
+      - '3000:80'  
     depends_on:
       - postgres
       - fedora

--- a/provisioning/docker_build/startup_scripts/01_db_migrate.sh
+++ b/provisioning/docker_build/startup_scripts/01_db_migrate.sh
@@ -1,2 +1,8 @@
 #!/bin/bash
+
+if [ "$RAILS_ENV" == "development" ]; then
+  echo "Waiting for postgres to be healthy enough to come up"
+  sleep 10
+fi
+
 cd /home/app/fedora_ingest_rails && RAILS_ENV=$RAILS_ENV bundle exec rake db:create db:migrate

--- a/provisioning/docker_build/startup_scripts/01_db_migrate.sh
+++ b/provisioning/docker_build/startup_scripts/01_db_migrate.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cd /home/app/fedora_ingest_rails && RAILS_ENV=production bundle exec rake db:create db:migrate
+cd /home/app/fedora_ingest_rails && RAILS_ENV=$RAILS_ENV bundle exec rake db:create db:migrate

--- a/provisioning/travis_ci_and_cd/build_and_push_to_ecr.sh
+++ b/provisioning/travis_ci_and_cd/build_and_push_to_ecr.sh
@@ -32,7 +32,7 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ] || [ "
     LOCAL_TAG_NAME=$IMAGE_NAME:$TRAVIS_BRANCH-latest
     REMOTE_FULL_URL=$DOCKER_REPO_URL:$TRAVIS_BRANCH-latest
 
-    docker build -t $LOCAL_TAG_NAME .
+    docker build --target production --tag $LOCAL_TAG_NAME .
     echo "Pushing $LOCAL_TAG_NAME"
     docker tag $LOCAL_TAG_NAME "$REMOTE_FULL_URL"
     docker push "$REMOTE_FULL_URL"


### PR DESCRIPTION
Howdy.

_There is zero rush to accept this PR.
I'd like you to play around with this, hopefully hit some bumps in the road, and think through potential bumps in the road and we can iterate on it._

This PR will allow us use Docker for local development as well as production without 
sacrificing hot-reloading in development or ability to use your regular-old text editor.

There are two parts to that...

## Changes

### Part 1:  One Dockerfile for both prod and local development.

In the past, our Dockerfile was used by travis to build an image.
That image is production-ready. It's `RAILS_ENV=production`, it doesn't bundle development or test
gems, etc...

[The new Dockerfile](https://github.com/NYPL/fedora_ingest_rails/blob/ss/make-easier-to-dockerize-locally/Dockerfile) uses [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) to be able to be built in either production mode or development mode. (development mode really just means `bundle install`ing test and dev gems)

And our [scripts that Travis uses to build the Dockerimage](https://github.com/NYPL/fedora_ingest_rails/blob/ss/make-easier-to-dockerize-locally/provisioning/travis_ci_and_cd/build_and_push_to_ecr.sh#L35) passes `--target production` to the `docker build` command.

### Part 2: Running All The Adjacent Apps

Running `docker-compose up` should bring up:

* This app and a delayed_job worker
* A persistent dockerized postgres for the app.
* A persistent dockerized filestoreDB (courtesy of [NYPL/filestore_databases_docker]( https://github.com/NYPL/filestore_databases_docker))
* An ephemeral, dockerized Fedora.
 
See [docker-compose.yml](https://github.com/NYPL/fedora_ingest_rails/blob/ss/make-easier-to-dockerize-locally/docker-compose.yml) to see how those services are all strung together).

## Finally

This app is simple enough to run locally natively - so I'd _love_ to use this PR as an excuse to spread the Docker love even if this PR goes nowhere.  Between multi-stage builds, docker-compose, and some docker-specific networking stuff - the simplicity of one-command running costs a little bit of a learning curve.

Take a look at [this branch's README](https://github.com/NYPL/fedora_ingest_rails/tree/ss/make-easier-to-dockerize-locally) and...

* Call me over as you try to get things running. 
* Let's have some discussion in this thread.