### PR TITLE
[KK] Rights aware image processing. Taking it deep zoom.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,9 @@ LINK_PASSWORD=link
 LINK_CREATE_BASE_URL=http://localhost:8081
 LINK_PUBLIC_BASE_URL=http://localhost:8081
 
+# Tilecutting service
+IMAGE_TILECUTTING_SERVICE_URL=http://example.867.53.09/captures
+
 #### VARIABLES USED FOR LOCAL DEVELOPMENT
 
 # You shouldn't want/have to edit these

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -87,7 +87,7 @@ IngestJob = Struct.new(:ingest_request_id) do
       request_tilecutting_for(uuids_for_tilecutting) if uuids_for_tilecutting.present?
       Delayed::Worker.logger.info("Sent uuids for tilecutting. #{uuids}", uuids: uuids_for_tilecutting)
     rescue Exception => e
-      Delayed::Worker.logger.error("Failed to send tilecutting request for #{uuids}", uuids: uuids_for_tilecutting)
+      Delayed::Worker.logger.error("Failed to send tilecutting request for #{uuids}, exception: #{e}", uuids: uuids_for_tilecutting)
     end
 
     Delayed::Worker.logger.info('Done ingesting all captures of Item', uuid: @ingest_request.uuid)

--- a/app/models/mms_client.rb
+++ b/app/models/mms_client.rb
@@ -44,7 +44,7 @@ class MMSClient
 
   private
 
-  # This DRYs up the pattern of making a request and throwing an exception for bad trsponses
+  # This DRYs up the pattern of making a request and throwing an exception for bad responses
   def make_request_for(export_type, uuid, params = {})
     response = authed_request.get(export_url_for(export_type, uuid), params: params)
     if response.code >= 400

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,7 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+
+# Constants common to all environments
+IMAGE_TILECUTTING_SERVICE_URL = ENV['IMAGE_TILECUTTING_SERVICE_URL']


### PR DESCRIPTION
Hi! Fresh new pull request for adding in a new call to the tilecutting processer during ingest. 

This new code introduces rights-aware asset processing. Specifically, captures that match our approved list of public domain copyright statuses should be sent automatically for tile cutting. 

Example of a capture uuid that matches (for testing purposes): 510d47e0-cc62-a3d9-e040-e00a18064a99. 

Doing this call from Fedora Ingest saves us extra time that would be needed in any other point in the pipeline. 