### PR TITLE
upgrade mimemagic gem and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ ADD ./provisioning/docker_build/startup_scripts/01_db_migrate.sh /etc/my_init.d/
 CMD ["/sbin/my_init"]
 
 EXPOSE 80
-RUN apt-get update
-# https://github.com/phusion/passenger-docker/issues/195
-RUN apt-get install -y tzdata
+
+RUN apt-get update -qq \
+    && apt-get install -y \
+    tzdata \
+    shared-mime-info
 
 # So nginx won't clear the environment variables (see notes in environment-variables.conf)
 ADD ./provisioning/docker_build/environment-variables.conf /etc/nginx/main.d/environment-variables.conf

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -251,4 +253,4 @@ DEPENDENCIES
   will_paginate (~> 3.1, >= 3.1.6)
 
 BUNDLED WITH
-   2.1.4
+   2.2.15


### PR DESCRIPTION
mimemagic 0.3.5 is no longer available, rendering this project unable to build. This upgrades mimemagic and installs the `shared-mime-info` dependency.