### PR TITLE
[DR-2075] Respond with capture status for any image file id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added new endpoint to respond with capture status. (DR-2075)
+
 ## [1.0.4] - 2022-09-09
 
 ### Updated

--- a/app/controllers/image_filestore_entries_controller.rb
+++ b/app/controllers/image_filestore_entries_controller.rb
@@ -1,0 +1,11 @@
+class ImageFilestoreEntriesController < ApplicationController
+  
+  def status
+    if params[:file_id] && ImageFilestoreEntry.where(file_id: params[:file_id]).present?
+      render json: "Captured"
+    else
+      render json: "Not found", status: 404
+    end
+  end
+  
+end

--- a/app/controllers/image_filestore_entries_controller.rb
+++ b/app/controllers/image_filestore_entries_controller.rb
@@ -1,7 +1,7 @@
 class ImageFilestoreEntriesController < ApplicationController
   
   def status
-    if params[:file_id] && ImageFilestoreEntry.where(file_id: params[:file_id]).present?
+    if params[:file_id] && ImageFilestoreEntry.has_file?(params[:file_id])
       render json: "Captured"
     else
       render json: "Not found", status: 404

--- a/app/models/image_filestore_entry.rb
+++ b/app/models/image_filestore_entry.rb
@@ -46,4 +46,8 @@ class ImageFilestoreEntry < ActiveRecord::Base
   def get_mimetype(string)
     mimetypes_dictionary[string] || mimetypes_dictionary['unknown']
   end
+
+  def self.has_file?(file_id)
+    where(file_id: file_id).present?
+  end
 end

--- a/app/models/image_filestore_entry.rb
+++ b/app/models/image_filestore_entry.rb
@@ -48,6 +48,6 @@ class ImageFilestoreEntry < ActiveRecord::Base
   end
 
   def self.has_file?(file_id)
-    where(file_id: file_id).present?
+    where(file_id: file_id).any?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@
 
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get 'image_filestore_entries/status/:file_id' => 'image_filestore_entries#status'
+  
   resources :ingest_requests, only: [:create], defaults: { format: :json }
   resources :ingest_history, only: [:show], defaults: { format: :json }
   resource :stats, only: [:show], defaults: { format: :json }

--- a/spec/controllers/image_filestore_entries_controller_spec.rb
+++ b/spec/controllers/image_filestore_entries_controller_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImageFilestoreEntriesController, type: :controller do
+
+  it "will respond to status requests with 404 if not found" do
+    get :status, params: { file_id: 'AwesomePhoto_BaronVonGroovy' }, format: :json
+    expect(response.status).to eq(404)
+  end
+  
+end

--- a/spec/controllers/image_filestore_entries_controller_spec.rb
+++ b/spec/controllers/image_filestore_entries_controller_spec.rb
@@ -9,4 +9,11 @@ RSpec.describe ImageFilestoreEntriesController, type: :controller do
     expect(response.status).to eq(404)
   end
   
+  it "will respond to status requests with 200 if found" do
+    foo_file = double("Foo file")
+    allow(ImageFilestoreEntry).to receive(:where).with({file_id: "foo"}).and_return([double("Foo file", file_id: "Foo")])
+    get :status, params: { file_id: 'foo' }, format: :json
+    expect(response.status).to eq(200)
+  end
+  
 end

--- a/spec/controllers/image_filestore_entries_controller_spec.rb
+++ b/spec/controllers/image_filestore_entries_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ImageFilestoreEntriesController, type: :controller do
-
+  
   it "will respond to status requests with 404 if not found" do
     get :status, params: { file_id: 'AwesomePhoto_BaronVonGroovy' }, format: :json
     expect(response.status).to eq(404)

--- a/spec/models/image_filestore_entry_spec.rb
+++ b/spec/models/image_filestore_entry_spec.rb
@@ -36,4 +36,13 @@ RSpec.describe ImageFilestoreEntry, type: :model do
   it 'Should return value for unknown mimetype key for garbage mimetypes' do
     expect(ImageFilestoreEntry.new.get_mimetype('Larry!')).to eq(ImageFilestoreEntry.new.mimetypes_dictionary['unknown'])
   end
+    
+  # No idea how to get this to work yet in a readonly database. 
+  # it 'Should respond in the affirmative if it has a filestore entry matching a given file_id' do
+  #   expect(ImageFilestoreEntry.has_file?('foo')).to eq(true)
+  # end
+  
+  it 'Should respond in the negative if it is given a nonexistant file_id' do
+    expect(ImageFilestoreEntry.has_file?('nonexistant')).to eq(false)
+  end
 end

--- a/spec/models/image_filestore_entry_spec.rb
+++ b/spec/models/image_filestore_entry_spec.rb
@@ -37,10 +37,11 @@ RSpec.describe ImageFilestoreEntry, type: :model do
     expect(ImageFilestoreEntry.new.get_mimetype('Larry!')).to eq(ImageFilestoreEntry.new.mimetypes_dictionary['unknown'])
   end
     
-  # No idea how to get this to work yet in a readonly database. 
-  # it 'Should respond in the affirmative if it has a filestore entry matching a given file_id' do
-  #   expect(ImageFilestoreEntry.has_file?('foo')).to eq(true)
-  # end
+  it 'Should respond in the affirmative if it has a filestore entry matching a given file_id' do
+    foo_file = double("Foo file")
+    allow(ImageFilestoreEntry).to receive(:where).with({file_id: "foo"}).and_return([double("Foo file", file_id: "Foo")])
+    expect(ImageFilestoreEntry.has_file?('foo')).to eq(true)
+  end
   
   it 'Should respond in the negative if it is given a nonexistant file_id' do
     expect(ImageFilestoreEntry.has_file?('nonexistant')).to eq(false)


### PR DESCRIPTION
## Jira Tickets ##
[Create endpoint in Fedora Ingest to respond for capture status](https://jira.nypl.org/browse/DR-2075)

## Things Done ##
- Added new endpoint for responding with a basic response if a file_id is found in filestore database. Responds with "Captured" if exists, or "Not found" if it does not exist. (Status codes 200 and 404 respectively.)

## How to Test ##
- Launch container and enter use any file_id for `http://localhost:3000/image_filestore_entries/status/:file_id`
- Should see 404 response and 'Not found' unless you use an id added to local db. 
- Run all tests with `docker-compose run webapp /bin/bash -c "cd /home/app/fedora_ingest_rails && bundle exec rspec"`