### PR TITLE
DR-2269 add first indexed to repoapi docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Accurately record first index date in repo api. (DR-2269)
+
 ### Fixed
 - Removed hierarchicalgeographic_mtxt from repoapi docs. (DR-2206)
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 group :test do
   gem 'shoulda-matchers', '~> 3.1', '>= 3.1.2'
+  gem 'spring-commands-rspec'
 end
 
 group :development, :test do
@@ -35,6 +36,7 @@ group :development, :test do
   gem 'pry', '~> 0.11.3'
   gem 'puma', '~> 4.3'
   gem 'rspec-rails', '~> 3.7', '>= 3.7.2'
+  gem 'spring'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,9 @@ GEM
       rest-client
     shoulda-matchers (3.1.3)
       activesupport (>= 4.0.0)
+    spring (3.1.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -246,6 +249,8 @@ DEPENDENCIES
   rubocop (~> 0.54.0)
   rubydora (~> 2.0)
   shoulda-matchers (~> 3.1, >= 3.1.2)
+  spring
+  spring-commands-rspec
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -17,7 +17,7 @@ module IngestJobHelper
 
     parent_uuids = []
     local_parent_and_item_repo_solr_docs_to_update = []
-    index_time = Time.now
+    index_time = Time.now.iso8601
 
     parent_and_item_repo_docs.each do |doc|
       doc_uuid = doc['uuid']
@@ -28,7 +28,7 @@ module IngestJobHelper
         doc['firstIndexed_s'] = index_time
         local_parent_and_item_repo_solr_docs_to_update << local_parent_or_item_repo_solr_doc
       else
-        doc['firstIndexed_s'] = local_parent_or_item_repo_solr_doc.first_indexed
+        doc['firstIndexed_s'] = local_parent_or_item_repo_solr_doc.first_indexed.to_time.iso8601
       end
     end
 
@@ -116,7 +116,7 @@ module IngestJobHelper
       end
 
       local_repo_capture_solr_doc = RepoSolrDoc.find_or_create_by!(uuid: uuid)
-      capture_solr_doc['firstIndexed_s'] = local_repo_capture_solr_doc&.first_indexed || index_time
+      capture_solr_doc['firstIndexed_s'] = local_repo_capture_solr_doc&.first_indexed&.to_time&.iso8601 || index_time
       local_repo_capture_solr_docs_to_update << local_repo_capture_solr_doc if local_repo_capture_solr_doc.first_indexed.nil?
 
       repo_solr.add_docs_to_solr(capture_solr_doc)

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -17,7 +17,7 @@ module IngestJobHelper
 
     parent_uuids = []
     local_parent_and_item_repo_solr_docs_to_update = []
-    index_time = Time.now.utc.iso8601
+    index_time = Time.now
 
     parent_and_item_repo_docs.each do |doc|
       doc_uuid = doc['uuid']

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+require 'nokogiri'
+
+module IngestJobHelper
+  def ingest!(ingest_request)
+    fedora_client = FedoraClient.new
+    mms_client = MMSClient.new(mms_url: Rails.application.secrets.mms_url,
+                               user_name: Rails.application.secrets.mms_http_basic_username,
+                               password: Rails.application.secrets.mms_http_basic_password)
+    rels_ext_index_client = RelsExtIndexClient.new(rels_ext_solr_url: Rails.application.secrets.rels_ext_solr_url)
+
+    # Fetch stuff from MMS
+    mods                        = mms_client.mods_for(ingest_request.uuid)
+    dublin_core                 = mms_client.dublin_core_for(ingest_request.uuid)
+    type_of_resource            = Nokogiri::XML(mods).css('typeOfResource:first').text
+    parent_and_item_repo_docs   = mms_client.repo_docs_for(ingest_request.uuid)
+
+    parent_uuids = []
+    local_parent_and_item_repo_solr_docs_to_update = []
+    index_time = Time.now.utc.iso8601
+
+    parent_and_item_repo_docs.each do |doc|
+      doc_uuid = doc['uuid']
+      parent_uuids << doc_uuid
+      local_parent_or_item_repo_solr_doc = RepoSolrDoc.find_or_create_by!(uuid: doc_uuid)
+
+      if local_parent_or_item_repo_solr_doc.first_indexed.nil?
+        doc['firstIndexed_s'] = index_time
+        local_parent_and_item_repo_solr_docs_to_update << local_parent_or_item_repo_solr_doc
+      else
+        doc['firstIndexed_s'] = local_parent_or_item_repo_solr_doc.first_indexed
+      end
+    end
+
+    # magic uuid for our one and only oral history collection. TODO:     Make this more universal. KAK - Sept 20 2021
+    in_oral_history_collection = parent_uuids.include?('da4687f0-cc71-0130-fb40-58d385a7b928')
+
+    repo_solr = RepoSolrClient.new
+    repo_solr.add_docs_to_solr(parent_and_item_repo_docs)
+
+    local_repo_capture_solr_docs_to_update = []
+
+    mms_client.captures_for_item(ingest_request.uuid).each do |capture|
+      uuid = capture[:uuid]
+      image_id = capture[:image_id]
+
+      # Pull rights for each capture. Needed because now we manage captures on an atomic level.
+      rights = mms_client.rights_for(uuid)
+
+      pid = "uuid:#{uuid}"
+
+      # Figure out if it is ok to release high res file. Handled by string in rights statement right now.
+      # necessary for determining if we need to get master image permalinks.
+      high_res_ok = 'Release Source File for Free (i.e., high-res or master can be released to the public)'
+      release_master = rights.to_s.scan(high_res_ok).present? if rights
+
+      digital_object = fedora_client.repository.find_or_initialize(pid)
+      digital_object.label = extract_title_from_dublin_core(dublin_core)[0..249]
+      digital_object.save
+      ##  For some reason this can only be done on saved objects
+      digital_object.models << 'info:fedora/nypl-model:image' # KK TODO: Ask JV why we do this and if it should apply to AMI.
+
+      # Datastreams with info from the `Item` Level
+      if mods.present?
+        fedora_client.repository.add_datastream(pid: pid, dsid: 'MODSXML', content: mods, mimeType: 'text/xml', checksumType: 'MD5', dsLabel: 'MODS XML record for this object')
+      end
+      if dublin_core.present?
+        fedora_client.repository.add_datastream(pid: pid, dsid: 'DC',      content: dublin_core, formatURI: 'http://www.openarchives.org/OAI/2.0/oai_dc/', mimeType: 'text/xml', checksumType: 'MD5', dsLabel: 'DC XML record for this object')
+      end
+
+      # Datastreams with info from the `Capture` level
+      if rights.present?
+        fedora_client.repository.add_datastream(pid: pid, dsid: 'RIGHTS',  content: rights, mimeType: 'text/xml', checksumType: 'MD5', dsLabel: 'Rights XML record for this object')
+      end
+
+      # Datastreams with info from the filestore database of image derivatives
+      image_filestore_entries = ImageFilestoreEntry.where(file_id: capture[:image_id], status: 4)
+      highres_permalink = nil
+      image_filestore_entries.each do |f|
+        file_uuid   = f.uuid
+        file_label  = f.get_type(f.type)
+        file_name   = f.file_name
+        extension   = file_name.split('.')[-1]
+        mime_type   = f.get_mimetype(extension)
+        if file_label == 'MASTER_IMAGE' && release_master
+          full_res_path = "#{FEDORA_LINK_URL}/objects/#{pid}/datastreams/MASTER_IMAGE/content"
+          highres_permalink = PermalinkClient.new(uuid: file_uuid).fetch_or_mint_permalink(full_res_path)
+        end
+        if file_label != 'Unknown'
+          datastream_options = { pid: pid, dsid: file_label, content: nil, controlGroup: 'E', mimeType: mime_type, checksumType: 'DISABLED', dsLocation: "http://local.fedora.server/resolver/#{file_uuid}", dsLabel: file_label + ' for this object', altIds: [highres_permalink] }
+          fedora_client.repository.add_datastream(datastream_options)
+        end
+      end
+
+      # Datastreams with info from the `Capture` Level
+      rels_ext = mms_client.rels_ext_for(uuid)
+
+      # Repo API solr for capture.
+      capture_solr_doc = mms_client.repo_doc_for(uuid)
+
+      if highres_permalink.present? && release_master
+        capture_solr_doc['highResLink'] = highres_permalink
+      else
+        capture_solr_doc['highResLink'] = nil # unpublishes the link if it exists.
+      end
+
+      if in_oral_history_collection
+        mets_alto = fedora_client.mets_alto_for(uuid)
+        capture_solr_doc['mets_alto'] = mets_alto
+        capture_solr_doc['hasOCR'] = capture_solr_doc['mets_alto'].present?
+
+        # Get the plain text from the alto.
+        ndoc = Nokogiri::XML(mets_alto)
+        plain_text = ndoc.xpath('//String').collect { |s| s.at('@CONTENT').text }.join(" ")
+        capture_solr_doc['captureText_ocrtext'] = plain_text
+      end
+
+      local_repo_capture_solr_doc = RepoSolrDoc.find_or_create_by!(uuid: uuid)
+      capture_solr_doc['firstIndexed_s'] = local_repo_capture_solr_doc&.first_indexed || index_time
+      local_repo_capture_solr_docs_to_update << local_repo_capture_solr_doc if local_repo_capture_solr_doc.first_indexed.nil?
+
+      repo_solr.add_docs_to_solr(capture_solr_doc)
+
+      if rels_ext.blank?
+        # Remove it from solr as there is a good chance it is there and should not be.
+        rels_ext_index_client.remove_doc_for(uuid)
+      else
+        # Write the doc to solr
+        rels_for_indexing = mms_client.full_rels_ext_solr_docs_for(uuid)
+        rels_indexer_response = rels_ext_index_client.post_solr_doc(uuid, rels_for_indexing)
+
+        # Post the datastream to the repository
+        fedora_client.repository.add_datastream(pid: pid, dsid: 'RELS-EXT', content: rels_ext, mimeType: 'application/rdf+xml', checksumType: 'MD5', dsLabel: 'RELS-EXT XML record for this object')
+      end
+
+      digital_object.save
+      Delayed::Worker.logger.info("ingested capture #{uuid}", uuid: ingest_request.uuid)
+    end
+
+    rels_ext_index_client.commit_index_changes
+    repo_solr.commit_index_changes
+
+    # do not update first indexed until we successfully return from commit
+    local_repo_capture_solr_docs_to_update.each { |d| d.update_attributes(first_indexed: index_time) }
+    local_parent_and_item_repo_solr_docs_to_update.each { |d| d.update_attributes(first_indexed: index_time) }
+
+    Delayed::Worker.logger.info('Done ingesting all captures of Item', uuid: ingest_request.uuid)
+  end
+
+  def extract_title_from_dublin_core(dublin_core)
+    Nokogiri::XML(dublin_core).remove_namespaces!.css('title').text.strip.truncate(250, separator: ' ...')
+  end
+end

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -1,140 +1,15 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
 Rubydora.logger = NyplLogFormatter.new(STDOUT)
 
 IngestJob = Struct.new(:ingest_request_id) do
+  include IngestJobHelper
+
   def perform
-    @ingest_request = IngestRequest.where(id: ingest_request_id).first
-    if @ingest_request
-      ingest!
-      @ingest_request.update_attributes(ingested_at: Time.now.utc)
+    ingest_request = IngestRequest.where(id: ingest_request_id).first
+    if ingest_request
+      ingest! ingest_request
+      ingest_request.update_attributes(ingested_at: Time.now.utc)
     end
-  end
-
-  def ingest!
-    fedora_client = FedoraClient.new
-    mms_client = MMSClient.new(mms_url: Rails.application.secrets.mms_url,
-                               user_name: Rails.application.secrets.mms_http_basic_username,
-                               password: Rails.application.secrets.mms_http_basic_password)
-    rels_ext_index_client = RelsExtIndexClient.new(
-      rels_ext_solr_url: Rails.application.secrets.rels_ext_solr_url
-    )
-
-    # Fetch stuff from MMS
-    mods                        = mms_client.mods_for(@ingest_request.uuid)
-    dublin_core                 = mms_client.dublin_core_for(@ingest_request.uuid)
-    type_of_resource            = Nokogiri::XML(mods).css('typeOfResource:first').text
-    parent_and_item_repo_docs   = mms_client.repo_docs_for(@ingest_request.uuid)
-    
-    parent_uuids = parent_and_item_repo_docs.collect { |d| d["uuid"] }
-    in_oral_history_collection = parent_uuids.include?('da4687f0-cc71-0130-fb40-58d385a7b928') # magic uuid for our one and only oral history collection. TODO: Make this more universal. KAK - Sept 20 2021
-
-    repo_solr = RepoSolrClient.new
-    repo_solr.add_docs_to_solr(parent_and_item_repo_docs)
-
-    mms_client.captures_for_item(@ingest_request.uuid).each do |capture|
-      uuid = capture[:uuid]
-      image_id = capture[:image_id]
-
-      # Pull rights for each capture. Needed because now we manage captures on an atomic level.
-      rights = mms_client.rights_for(uuid)
-
-      pid = "uuid:#{uuid}"
-      
-      # Figure out if it is ok to release high res file. Handled by string in rights statement right now.
-      # necessary for determining if we need to get master image permalinks.
-      high_res_ok = 'Release Source File for Free (i.e., high-res or master can be released to the public)'
-      release_master = rights.to_s.scan(high_res_ok).present? if rights
-
-      digital_object = fedora_client.repository.find_or_initialize(pid)
-      digital_object.label = extract_title_from_dublin_core(dublin_core)[0..249]
-      digital_object.save
-      ##  For some reason this can only be done on saved objects
-      digital_object.models << 'info:fedora/nypl-model:image' # KK TODO: Ask JV why we do this and if it should apply to AMI.
-
-      # Datastreams with info from the `Item` Level
-      if mods.present?
-        fedora_client.repository.add_datastream(pid: pid, dsid: 'MODSXML', content: mods, mimeType: 'text/xml', checksumType: 'MD5', dsLabel: 'MODS XML record for this object')
-      end
-      if dublin_core.present?
-        fedora_client.repository.add_datastream(pid: pid, dsid: 'DC',      content: dublin_core, formatURI: 'http://www.openarchives.org/OAI/2.0/oai_dc/', mimeType: 'text/xml', checksumType: 'MD5', dsLabel: 'DC XML record for this object')
-      end
-
-      # Datastreams with info from the `Capture` level
-      if rights.present?
-        fedora_client.repository.add_datastream(pid: pid, dsid: 'RIGHTS',  content: rights, mimeType: 'text/xml', checksumType: 'MD5', dsLabel: 'Rights XML record for this object')
-      end
-
-      # Datastreams with info from the filestore database of image derivatives
-      image_filestore_entries = ImageFilestoreEntry.where(file_id: capture[:image_id], status: 4)
-      highres_permalink = nil
-      image_filestore_entries.each do |f|
-        file_uuid   = f.uuid
-        file_label  = f.get_type(f.type)
-        file_name   = f.file_name
-        extension   = file_name.split('.')[-1]
-        mime_type   = f.get_mimetype(extension)
-        if file_label == 'MASTER_IMAGE' && release_master
-          full_res_path = "#{FEDORA_LINK_URL}/objects/#{pid}/datastreams/MASTER_IMAGE/content"
-          highres_permalink = PermalinkClient.new(uuid: file_uuid).fetch_or_mint_permalink(full_res_path)
-        end
-        if file_label != 'Unknown'
-          datastream_options = { pid: pid, dsid: file_label, content: nil, controlGroup: 'E', mimeType: mime_type, checksumType: 'DISABLED', dsLocation: "http://local.fedora.server/resolver/#{file_uuid}", dsLabel: file_label + ' for this object', altIds: [highres_permalink] }
-          fedora_client.repository.add_datastream(datastream_options)
-        end
-      end
-
-      # Datastreams with info from the `Capture` Level
-      rels_ext = mms_client.rels_ext_for(uuid)
-      
-      # Repo API solr for capture.
-      capture_solr_doc = mms_client.repo_doc_for(uuid)
-      
-      if highres_permalink.present? && release_master
-        capture_solr_doc["highResLink"] = highres_permalink 
-      else
-        capture_solr_doc["highResLink"] = nil # unpublishes the link if it exists. 
-      end
-      
-      if in_oral_history_collection
-        mets_alto = fedora_client.mets_alto_for(uuid)
-        capture_solr_doc["mets_alto"] = mets_alto
-        capture_solr_doc["hasOCR"] = capture_solr_doc["mets_alto"].present?
-        
-        # Get the plain text from the alto.
-        ndoc = Nokogiri::XML(mets_alto)
-        plain_text = ndoc.xpath("//String").collect { |s| s.at('@CONTENT').text }.join(" ")
-        capture_solr_doc["captureText_ocrtext"] = plain_text
-      end
-      
-      repo_solr.add_docs_to_solr(capture_solr_doc)
-
-      if rels_ext.blank?
-        # Remove it from solr as there is a good chance it is there and should not be.
-        rels_ext_index_client.remove_doc_for(uuid)
-      else
-        # Write the doc to solr
-        rels_for_indexing = mms_client.full_rels_ext_solr_docs_for(uuid)
-        rels_indexer_response = rels_ext_index_client.post_solr_doc(uuid, rels_for_indexing)
-
-        # Post the datastream to the repository
-        fedora_client.repository.add_datastream(pid: pid, dsid: 'RELS-EXT', content: rels_ext, mimeType: 'application/rdf+xml', checksumType: 'MD5', dsLabel: 'RELS-EXT XML record for this object')
-      end
-
-      digital_object.save
-      Delayed::Worker.logger.info("ingested capture #{uuid}", uuid: @ingest_request.uuid)
-    end
-
-    rels_ext_index_client.commit_index_changes
-    repo_solr.commit_index_changes
-
-    Delayed::Worker.logger.info('Done ingesting all captures of Item', uuid: @ingest_request.uuid)
-  end
-
-  private
-
-  def extract_title_from_dublin_core(dublin_core)
-    Nokogiri::XML(dublin_core).remove_namespaces!.css('title').text.strip.truncate(250, separator: ' ...')
   end
 end

--- a/app/models/fedora_client.rb
+++ b/app/models/fedora_client.rb
@@ -11,7 +11,7 @@ class FedoraClient
       password: Rails.application.secrets.fedora_password
     )
   end
-  
+
   def mets_alto_for(uuid)
     require 'open-uri'
     this_url = "fedora/objects/uuid:#{uuid}/datastreams/METS_ALTO/content"

--- a/app/models/mms_client.rb
+++ b/app/models/mms_client.rb
@@ -69,6 +69,7 @@ class MMSClient
     'dateDigitized_dt',
     'dateIndexed_s',
     'firstInSequence',
+    'firstIndexed_s',
     'highResLink',
     'identifier_idx_local_brightcove_id',
     'identifier_idx_local_brightcove_key',

--- a/app/models/repo_solr_client.rb
+++ b/app/models/repo_solr_client.rb
@@ -35,7 +35,7 @@ class RepoSolrClient
   def commit_index_changes
     @repo_solr_client.commit if @repo_solr_client
   end
-  
+
   def get_solr_doc_for(uuid)
     mms_client = MMSClient.new(mms_url: Rails.application.secrets.mms_url)
     mms_client.repoapi_solr_doc_for(uuid)

--- a/app/models/repo_solr_doc.rb
+++ b/app/models/repo_solr_doc.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class RepoSolrDoc < ApplicationRecord
+  validates_presence_of :uuid
+end

--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 
 begin
   load File.expand_path('spring', __dir__)

--- a/bin/rake
+++ b/bin/rake
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 
 begin
   load File.expand_path('spring', __dir__)

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
 
-# This file loads spring without using Bundler, in order to be fast.
+# This file loads Spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,8 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.enable_reloading = true
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -3,11 +3,13 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.enable_reloading = true
+
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/db/migrate/20230412181309_create_repo_solr_docs.rb
+++ b/db/migrate/20230412181309_create_repo_solr_docs.rb
@@ -1,0 +1,13 @@
+class CreateRepoSolrDocs < ActiveRecord::Migration[5.2]
+  def up
+    create_table :repo_solr_docs do |t|
+      t.string :uuid, limit: 36
+      t.timestamp :first_indexed
+    end
+    add_index :repo_solr_docs, :uuid, unique: true
+  end
+
+  def down
+    drop_table :repo_solr_docs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,30 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_180_322_171_453) do
+ActiveRecord::Schema.define(version: 2023_04_12_181309) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'delayed_jobs', force: :cascade do |t|
-    t.integer 'priority', default: 0, null: false
-    t.integer 'attempts', default: 0, null: false
-    t.text 'handler', null: false
-    t.text 'last_error'
-    t.datetime 'run_at'
-    t.datetime 'locked_at'
-    t.datetime 'failed_at'
-    t.string 'locked_by'
-    t.string 'queue'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.index %w[priority run_at], name: 'delayed_jobs_priority'
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table 'ingest_requests', id: :serial, force: :cascade do |t|
-    t.string 'uuid'
-    t.datetime 'ingested_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['uuid'], name: 'index_ingest_requests_on_uuid'
+  create_table "ingest_requests", id: :serial, force: :cascade do |t|
+    t.string "uuid"
+    t.datetime "ingested_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uuid"], name: "index_ingest_requests_on_uuid"
   end
+
+  create_table "repo_solr_docs", force: :cascade do |t|
+    t.string "uuid", limit: 36
+    t.datetime "first_indexed"
+    t.index ["uuid"], name: "index_repo_solr_docs_on_uuid", unique: true
+  end
+
 end

--- a/spec/helpers/ingest_job_helper_spec.rb
+++ b/spec/helpers/ingest_job_helper_spec.rb
@@ -1,0 +1,167 @@
+require 'rails_helper'
+
+RSpec.describe 'IngestHelper', type: :helper do
+  describe '#ingest!' do
+    subject { helper.ingest!(ingest_request) }
+
+    let(:ingest_request) { create(:ingest_request) }
+
+    let(:mock_logger) { double('logger', :info => true) }
+    let(:mock_fedora_client) { double('fedora_client', :repository => repository) }
+
+    let(:repository) {
+      double('repository',
+        :find_or_initialize => digital_object,
+        :add_datastream => true
+      )
+    }
+
+    let(:digital_object) {
+      double('digital_object',
+        'label=' => true,
+        :save => true,
+        :models => []
+      )
+    }
+
+    let(:mock_mms_client) {
+      double('mms_client',
+        :mods_for => mods,
+        :dublin_core_for => dublin_core,
+        :repo_docs_for => repo_docs,
+        :captures_for_item => captures,
+        :rights_for => rights,
+        :rels_ext_for => rels_ext,
+        :repo_doc_for => true,
+        :full_rels_ext_solr_docs_for => rels_ext_solr_docs
+      )
+    }
+
+    let(:mods) { 'some_mods' }
+    let(:dublin_core) { 'some_dublin_core' }
+    let(:repo_docs) { [repo_doc_1, repo_doc_2] }
+    let(:repo_doc_1) { { 'uuid' => 'repo_doc_1_uuid' } }
+    let(:repo_doc_2) { { 'uuid' => 'repo_doc_2_uuid' } }
+    let(:captures) { [capture_1, capture_2] }
+    let(:capture_1) { { :uuid => 'capture_1_uuid' } }
+    let(:capture_2) { { :uuid => 'capture_2_uuid' } }
+    let(:indexed_uuids) { [repo_doc_1['uuid'], repo_doc_2['uuid'], capture_1[:uuid], capture_2[:uuid]] }
+    let(:rights) { 'some_rights' }
+    let(:rels_ext) { 'some_rels_ext' }
+    let(:rels_ext_solr_docs) { 'some_rels_ext_solr_docs' }
+
+    let(:mock_rels_ext_index_client) {
+      double('rels_client',
+        :post_solr_doc => true,
+        :commit_index_changes => true
+      )
+    }
+
+    let(:mock_repo_solr_client) {
+      double('repo_solr_client',
+        :add_docs_to_solr => true,
+        :commit_index_changes => true
+      )
+    }
+
+    before do
+      allow(Delayed::Worker).to receive(:logger).and_return(mock_logger)
+      allow(FedoraClient).to receive(:new).and_return(mock_fedora_client)
+      allow(MMSClient).to receive(:new).and_return(mock_mms_client)
+      allow(RelsExtIndexClient).to receive(:new).and_return(mock_rels_ext_index_client)
+      allow(RepoSolrClient).to receive(:new).and_return(mock_repo_solr_client)
+      allow(mock_mms_client).to receive(:repo_doc_for).with(capture_1[:uuid]).and_return(capture_1).once
+      allow(mock_mms_client).to receive(:repo_doc_for).with(capture_2[:uuid]).and_return(capture_2).once
+    end
+
+    context 'the indexing time is known' do
+      before { allow(Time).to receive(:now).and_return(known_datetime) }
+
+      let(:known_datetime) { DateTime.parse('2023-04-13 15:07:25 +0000') }
+      let(:expected_datetime) { known_datetime.utc.iso8601 }
+
+      let(:expected_parent_and_item_repo_solr_docs) { [parent_or_item_repo_solr_doc_1, parent_or_item_repo_solr_doc_2] }
+      let(:parent_or_item_repo_solr_doc_1) {
+        {
+          'firstIndexed_s' => expected_datetime,
+          'uuid' => repo_doc_1['uuid']
+        }
+      }
+      let(:parent_or_item_repo_solr_doc_2) {
+        {
+          'firstIndexed_s' => expected_datetime,
+          'uuid' => repo_doc_2['uuid']
+        }
+      }
+
+      let(:expected_capture_solr_doc_1) {
+        {
+          'firstIndexed_s' => expected_datetime,
+          'highResLink' => nil,
+          :uuid => capture_1[:uuid]
+        }
+      }
+      let(:expected_capture_solr_doc_2) {
+        {
+          'firstIndexed_s' => expected_datetime,
+          'highResLink' => nil,
+          :uuid => capture_2[:uuid]
+        }
+      }
+
+      it 'adds firstIndexed_s to all the repo solr docs' do
+        expect(mock_repo_solr_client).to receive(:add_docs_to_solr).with(expected_parent_and_item_repo_solr_docs).once
+        expect(mock_repo_solr_client).to receive(:add_docs_to_solr).with(expected_capture_solr_doc_1).once
+        expect(mock_repo_solr_client).to receive(:add_docs_to_solr).with(expected_capture_solr_doc_2).once
+        subject
+      end
+    end
+
+    context 'none of the repo solr docs exist' do
+      it 'creates the parent and item repo solr docs and sets their first indexed values' do
+        subject
+        from_db_1 = RepoSolrDoc.find_by(uuid: repo_doc_1['uuid'])
+        from_db_2 = RepoSolrDoc.find_by(uuid: repo_doc_2['uuid'])
+        expect(from_db_1).not_to be_nil
+        expect(from_db_2).not_to be_nil
+        expect(from_db_1.first_indexed).not_to be_nil
+        expect(from_db_2.first_indexed).not_to be_nil
+      end
+
+      it 'creates the capture repo solr docs and sets their first indexed values' do
+        subject
+        from_db_1 = RepoSolrDoc.find_by(uuid: capture_1[:uuid])
+        from_db_2 = RepoSolrDoc.find_by(uuid: capture_2[:uuid])
+        expect(from_db_1).not_to be_nil
+        expect(from_db_2).not_to be_nil
+        expect(from_db_1.first_indexed).not_to be_nil
+        expect(from_db_2.first_indexed).not_to be_nil
+      end
+    end
+
+    context 'all of the repo solr docs exist' do
+      context 'and all of them have first indexed values' do
+        before do
+          first_indexed_time = Time.now - 3.days
+          indexed_uuids.each { |uuid| RepoSolrDoc.create!(uuid: uuid, first_indexed: first_indexed_time) }
+        end
+
+        it 'does not update their first indexed values' do
+          expected_first_indexed_time = RepoSolrDoc.first.first_indexed
+          subject
+          RepoSolrDoc.all.each { |doc| expect(doc.first_indexed).to eq(expected_first_indexed_time) }
+        end
+      end
+
+      context 'and none of them have first indexed values' do
+        before { indexed_uuids.each { |uuid| RepoSolrDoc.create!(uuid: uuid) } }
+
+        it 'updates their first indexed values' do
+          expected_first_indexed_time = RepoSolrDoc.first.first_indexed
+          subject
+          RepoSolrDoc.all.each { |doc| expect(doc.first_indexed).not_to be_nil }
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/ingest_job_helper_spec.rb
+++ b/spec/helpers/ingest_job_helper_spec.rb
@@ -78,32 +78,31 @@ RSpec.describe 'IngestHelper', type: :helper do
       before { allow(Time).to receive(:now).and_return(known_datetime) }
 
       let(:known_datetime) { DateTime.parse('2023-04-13 15:07:25 +0000') }
-      let(:expected_datetime) { known_datetime.utc.iso8601 }
 
       let(:expected_parent_and_item_repo_solr_docs) { [parent_or_item_repo_solr_doc_1, parent_or_item_repo_solr_doc_2] }
       let(:parent_or_item_repo_solr_doc_1) {
         {
-          'firstIndexed_s' => expected_datetime,
+          'firstIndexed_s' => known_datetime,
           'uuid' => repo_doc_1['uuid']
         }
       }
       let(:parent_or_item_repo_solr_doc_2) {
         {
-          'firstIndexed_s' => expected_datetime,
+          'firstIndexed_s' => known_datetime,
           'uuid' => repo_doc_2['uuid']
         }
       }
 
       let(:expected_capture_solr_doc_1) {
         {
-          'firstIndexed_s' => expected_datetime,
+          'firstIndexed_s' => known_datetime,
           'highResLink' => nil,
           :uuid => capture_1[:uuid]
         }
       }
       let(:expected_capture_solr_doc_2) {
         {
-          'firstIndexed_s' => expected_datetime,
+          'firstIndexed_s' => known_datetime,
           'highResLink' => nil,
           :uuid => capture_2[:uuid]
         }


### PR DESCRIPTION
## Jira Tickets ##
[Create new field to accurately record first index date in repo api](https://jira.nypl.org/browse/DR-2269)

## Things Done ##
- Created a new db table for `first_indexed` by doc uuid
- Apply `firstIndexed_s` to repo docs that are indexed
- Added unit tests
- Moved ingest logic into a helper to make it more easily testable
- Added spring

## How to Test ##
- `bundle install`
- `bundle exec rake bin/rspec spec/helpers/ingest_job_helper_spec.rb`
- See: https://github.com/NYPL/fedora_ingest_rails/pull/97