### PR TITLE
DR-2269 repoapi first index field test considerations

### DIFF
--- a/app/controllers/ingest_requests_controller.rb
+++ b/app/controllers/ingest_requests_controller.rb
@@ -5,7 +5,8 @@ class IngestRequestsController < ApplicationController
 
   def create
     uuids = params[:uuids].compact.uniq.map(&:strip)
-    uuids.each { |uuid| IngestRequest.create(uuid: uuid) }
+    test_mode = params[:test_mode] || false
+    uuids.each { |uuid| IngestRequest.create(uuid: uuid, test_mode: test_mode) }
     head :created
   end
 end

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -22,7 +22,7 @@ module IngestJobHelper
 
     parent_uuids = []
     local_parent_and_item_repo_solr_docs_to_update = []
-    index_time = Time.now
+    index_time = Time.now.iso8601
 
     parent_and_item_repo_docs.each do |doc|
       doc_uuid = doc['uuid']
@@ -33,7 +33,7 @@ module IngestJobHelper
         doc['firstIndexed_s'] = index_time
         local_parent_and_item_repo_solr_docs_to_update << local_parent_or_item_repo_solr_doc
       else
-        doc['firstIndexed_s'] = local_parent_or_item_repo_solr_doc.first_indexed
+        doc['firstIndexed_s'] = local_parent_or_item_repo_solr_doc.first_indexed.to_time.iso8601
       end
     end
 
@@ -128,7 +128,7 @@ module IngestJobHelper
       end
 
       local_repo_capture_solr_doc = RepoSolrDoc.find_or_create_by!(uuid: uuid)
-      capture_solr_doc['firstIndexed_s'] = local_repo_capture_solr_doc&.first_indexed || index_time
+      capture_solr_doc['firstIndexed_s'] = local_repo_capture_solr_doc&.first_indexed&.to_time&.iso8601 || index_time
       local_repo_capture_solr_docs_to_update << local_repo_capture_solr_doc if local_repo_capture_solr_doc.first_indexed.nil?
 
       repo_solr.add_docs_to_solr(capture_solr_doc)

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -2,13 +2,13 @@
 
 Rubydora.logger = NyplLogFormatter.new(STDOUT)
 
-IngestJob = Struct.new(:ingest_request_id) do
+IngestJob = Struct.new(:ingest_request_id, :test_mode) do
   include IngestJobHelper
 
   def perform
     ingest_request = IngestRequest.where(id: ingest_request_id).first
     if ingest_request
-      ingest! ingest_request
+      ingest!(ingest_request, test_mode)
       ingest_request.update_attributes(ingested_at: Time.now.utc)
     end
   end

--- a/app/models/ingest_request.rb
+++ b/app/models/ingest_request.rb
@@ -6,12 +6,14 @@ class IngestRequest < ApplicationRecord
 
   validates_presence_of :uuid
   validate :not_already_pending_validation, on: :create
+
+  attr_accessor :test_mode
   after_create :send_to_fedora, on: :create
 
   private
 
   def send_to_fedora
-    Delayed::Job.enqueue(IngestJob.new(id))
+    Delayed::Job.enqueue(IngestJob.new(id, test_mode))
   end
 
   def not_already_pending_validation

--- a/spec/controllers/ingest_requests_controller_spec.rb
+++ b/spec/controllers/ingest_requests_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe IngestRequestsController, type: :controller do
   it 'will call create on UUID sent to it' do
     uuids = %w[1 2 3 4 5]
     uuids.each do |uuid|
-      expect(IngestRequest).to receive(:create).with({ uuid: uuid })
+      expect(IngestRequest).to receive(:create).with({ uuid: uuid, test_mode: false })
     end
     post :create, params: { uuids: uuids }, format: :json
   end
@@ -14,8 +14,8 @@ RSpec.describe IngestRequestsController, type: :controller do
   it "won't try to create duplicate UUIDs" do
     IngestRequest.destroy_all
     uuids = %w[1 1 2]
-    expect(IngestRequest).to receive(:create).with({ uuid: '2' }).exactly(1).times
-    expect(IngestRequest).to receive(:create).with({ uuid: '1' }).exactly(1).times
+    expect(IngestRequest).to receive(:create).with({ uuid: '2', test_mode: false }).exactly(1).times
+    expect(IngestRequest).to receive(:create).with({ uuid: '1', test_mode: false }).exactly(1).times
     post :create, params: { uuids: uuids }, format: :json
   end
 


### PR DESCRIPTION
## Jira Tickets ##
[Create new field to accurately record first index date in repo api](https://jira.nypl.org/browse/DR-2269)

## Things Done ##
- Added a test mode to bypass fedora and rels ext index

## How to Test ##
- Post an item uuid and test_mode: true to fedora ingest.
- Retrieve the document from solr by uuid. It should have been posted successfully.
More thorough testing steps are forthcoming

Here are step by step instructions:

### Local Development ###
- rebuild your fedora ingest application to add recent dependencies: `docker-compose build`
- Configure your application to use some QA "stuff" (you'll want to revert these changes when you're done testing)
```
# these connections are not used locally _or_ in qa but can help prove out that fedora ingest test mode works without them
FEDORA_USERNAME=fedoraAdmin #qa 
FEDORA_PASSWORD='COWwNBsuHUWmliEDNZUpvIRGQVXhKprTK7hcxMRLkw8ZctoSUj' #qa 
FEDORA_URL='http://qa01-fmaster.repo.nypl.org:8080/fedora' #qa 

IMAGE_FILESTORE_DATABASE_HOST='prod.mysql.nypl.org' #qa 
IMAGE_FILESTORE_DATABASE_NAME=archive #qa 
IMAGE_FILESTORE_DATABASE_USER=digital_read #qa 
IMAGE_FILESTORE_DATABASE_PASSWORD=d1g1t@l #qa 

AMI_FILESTORE_DATABASE_HOST='' #qa 
AMI_FILESTORE_DATABASE_NAME='' #qa 
AMI_FILESTORE_DATABASE_USER='' #qa
AMI_FILESTORE_DATABASE_PASSWORD=mysqlpassword #qa

MMS_URL='https://qa-metadata.nypl.org:443'

# also not used
RELS_EXT_SOLR_URL='http://qa01-solr.repo.nypl.org:8080/solr-3.5/repoRels' #qa
RELS_EXT_USERNAME=solradmin #qa
RELS_EXT_PASSWORD='999][lEvels' #qa

REPO_SOLR_URL=http://10.225.131.109:8983/solr/repoapi
```
- bring up your app with `docker-compose up` and in another tab do `docker-compose run webapp bash`. Once in the webapp, do `bundle exec rake db:migrate` to get the most recent table added.
- in your webapp session, cd to /logs and `tail -f development.log`
- Open postman and do a post to http://localhost:3000/ingest_requests with these properties:
    - Add Header `Content-Type: application/json`
    - Add Body -> raw 
```
{
    "uuids": ["14b44ac0-c08a-0134-67c6-00505686a51c"],
    "test_mode": true
}
```
   - NB: please swap out item uuid as you want but ensure that the item is indexed already - for example: `http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%2214b44ac0-c08a-0134-67c6-00505686a51c%22)))`
- Post the post. You should get back a 201 Created with an empty body
- Check the development logs. There should be no errors and the Delayed Worker should have worked off the existing job successfully.
- Check out `http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%2214b44ac0-c08a-0134-67c6-00505686a51c%22)))` (or whatever your doc is). It should have an updated `firstIndexed_s` value based on the time you posted (e.g. `"firstIndexed_s":["2023-04-14T20:46:02+00:00"]`)
- Post the same request again any number of times. These should all succeed, but the value of firstIndexed_s should not update on the doc.
- For more validation, you can go into the rails console and look up the existing RepoSolrDoc uuids. Each uuid should have a corresponding repoapi solr document indexed with a firstIndexed_s value.
- At any juncture, you can `RepoSolrDoc.destroy_all` to start fresh on the solr timestamps but be aware that every dev and qa member is using the same development repo core, so it'll be quite easy to clobber one another. Additionally, doing this from local generates timestamps that will become out of sync with those in the fedora ingest qa database until an item is re-ingested. We might need to consider some tooling to sync these up.


### QA ###
- Acccessinate at http://nypl-digital-dev.nypl.org/index.php
- Open postman and do a post to https://qa-fedora-ingestor.nypl.org/ingest_requests with these properties:
    - Add Header `Content-Type: application/json`
    - Add Body -> raw 
```
{
    "uuids": ["14b44ac0-c08a-0134-67c6-00505686a51c"],
    "test_mode": true
}
```
   - NB: please swap out item uuid as you want but ensure that the item is indexed already - for example: http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%2214b44ac0-c08a-0134-67c6-00505686a51c%22)))
   - Check out http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%2214b44ac0-c08a-0134-67c6-00505686a51c%22))) (or whatever your doc is). It should have an updated `firstIndexed_s` value based on the time you posted (e.g. `"firstIndexed_s":["2023-04-14T20:46:02+00:00"]`)
   - Post the same request again any number of times. These should all succeed, but the value of firstIndexed_s should not update on the doc.
   
## Questions ##
- With the changes to parameters, can previously queued up ingest requests still complete successfully? May need some consideration and local testing to ensure this.