### PR TITLE
Update production docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY --chown=app:app . /home/app/fedora_ingest_rails
 # https://stackoverflow.com/questions/47972479/after-ruby-update-to-2-5-0-require-bundler-setup-raise-exception
 RUN cd /home/app/fedora_ingest_rails && gem update --system
 RUN cd /home/app/fedora_ingest_rails && gem install bundler
-RUN cd /home/app/fedora_ingest_rails && BUNDLER_WITHOUT="development test" bundle install
+RUN cd /home/app/fedora_ingest_rails && bundle install -V --without test development
 
 # Enables ngnix+passenger
 RUN rm -f /etc/service/nginx/down


### PR DESCRIPTION
## Jira Tickets ##
N/A

## Things Done ##
- Made the Dockerfile bundle install correctly exclude development and test groups

## How to Test ##

### Local Dev ###
- In a webapp container, do `BUNDLER_WITHOUT="development test" bundle install` and then `RAILS_ENV=production bundle exec rails c`. You should see spring in the install output and also an error complaining about spring when trying to start the console.
- Instead, do `bundle install -V --without test development`. There should be no spring in the output. Also, `RAILS_ENV=production bundle exec rails c` should get past the spring error and complain about something else that isn't set up locally. This is expected.

### In QA ###
- The webapp can start again

