### PR TITLE
DR-2302 use a default s3 region

### DIFF
--- a/app/models/s3_client.rb
+++ b/app/models/s3_client.rb
@@ -2,11 +2,7 @@
 
 class S3Client
   def initialize
-    Aws::S3::Client.new(
-      region: (ENV['AWS_REGION'] || 'us-east-1'),
-      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
-    )
+    Aws::S3::Client.new(region: (ENV['AWS_REGION'] || 'us-east-1'), access_key_id: ENV['AWS_ACCESS_KEY_ID'], secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
   end
 
   def mets_alto_for(uuid)

--- a/app/models/s3_client.rb
+++ b/app/models/s3_client.rb
@@ -2,7 +2,12 @@
 
 class S3Client
   def initialize
-    @s3 ||= Aws::S3::Client.new(region: ENV['AWS_REGION'], access_key_id: ENV['AWS_ACCESS_KEY_ID'], secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
+    s3_client_params = {
+      region: (ENV['AWS_REGION'] || 'us-east-1'),
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+    }
+    @s3 ||= Aws::S3::Client.new(s3_client_params)
   end
 
   def mets_alto_for(uuid)

--- a/app/models/s3_client.rb
+++ b/app/models/s3_client.rb
@@ -15,8 +15,6 @@ class S3Client
 
     return nil unless raw_xml
 
-    puts "raw xml: #{raw_xml}"
-
     mets_alto_doc = Nokogiri::XML(raw_xml)
     mets_alto_doc.remove_namespaces!
     mets_alto = mets_alto_doc.to_xml

--- a/app/models/s3_client.rb
+++ b/app/models/s3_client.rb
@@ -2,12 +2,11 @@
 
 class S3Client
   def initialize
-    s3_client_params = {
+    Aws::S3::Client.new(
       region: (ENV['AWS_REGION'] || 'us-east-1'),
       access_key_id: ENV['AWS_ACCESS_KEY_ID'],
       secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
-    }
-    @s3 ||= Aws::S3::Client.new(s3_client_params)
+    )
   end
 
   def mets_alto_for(uuid)

--- a/app/models/s3_client.rb
+++ b/app/models/s3_client.rb
@@ -2,7 +2,7 @@
 
 class S3Client
   def initialize
-    Aws::S3::Client.new(region: (ENV['AWS_REGION'] || 'us-east-1'), access_key_id: ENV['AWS_ACCESS_KEY_ID'], secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
+    @s3 ||= Aws::S3::Client.new(region: (ENV['AWS_REGION'] || 'us-east-1'), access_key_id: ENV['AWS_ACCESS_KEY_ID'], secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
   end
 
   def mets_alto_for(uuid)
@@ -14,6 +14,8 @@ class S3Client
     end
 
     return nil unless raw_xml
+
+    puts "raw xml: #{raw_xml}"
 
     mets_alto_doc = Nokogiri::XML(raw_xml)
     mets_alto_doc.remove_namespaces!


### PR DESCRIPTION
## Jira Tickets ##
[Move OCR data from Fedora to an S3 bucket (qa and production)](https://jira.nypl.org/browse/DR-2302)

## Things Done ##
- Set a default S3 region in the case that one is not overridden in the task definition. Without this change, the delayed jobs were erroring in qa when initializing the s3 client.


## How to Test ##

### Local Testing ###
-  Remove AWS_REGION from your .env
- Open a rails console inside the worker container and do S3Client.new. It should work without error.
  