### PR TITLE
DR-2269 add first indexed v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@
 # are hard-wired to work out-of-the-box on the dockerized stack (see docker-compose.yml)
 # Only change these if you want to connect to other instances.
 
+#QA DB
+#DATABASE_NAME=<get_from_secrets_manager>
+#DATABASE_USER_NAME=<get_from_secrets_manager>
+#DATABASE_PASSWORD=<get_from_secrets_manager>
+#DATABASE_HOST=<get_from_secrets_manager>
+
 # AWS
 AWS_ACCESS_KEY_ID=<get_from_secrets_manager>
 AWS_SECRET_ACCESS_KEY=<get_from_secrets_manager>

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,18 @@ RUN apt-get install -y tzdata
 # So nginx won't clear the environment variables (see notes in environment-variables.conf)
 ADD ./provisioning/docker_build/environment-variables.conf /etc/nginx/main.d/environment-variables.conf
 
+## Bundle Gems
+COPY Gemfile /home/app/fedora_ingest_rails/
+COPY Gemfile.lock /home/app/fedora_ingest_rails/
+WORKDIR /home/app/fedora_ingest_rails
+RUN gem update --system
+RUN gem install bundler
+
 # Passenger Configuration & App
 RUN rm /etc/nginx/sites-enabled/default
 ADD ./provisioning/docker_build/fedora_ingest_rails.conf /etc/nginx/sites-enabled/fedora_ingest_rails.conf
 COPY --chown=app:app . /home/app/fedora_ingest_rails
-
-## Bundle Gems
-RUN cd /home/app/fedora_ingest_rails && gem update --system
-RUN cd /home/app/fedora_ingest_rails && gem install bundler
-RUN cd /home/app/fedora_ingest_rails && bundle install -V --without test development
+RUN bundle install -V --without test development
 
 # Enables ngnix+passenger
 RUN rm -f /etc/service/nginx/down

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ ADD ./provisioning/docker_build/fedora_ingest_rails.conf /etc/nginx/sites-enable
 COPY --chown=app:app . /home/app/fedora_ingest_rails
 
 ## Bundle Gems
-# https://stackoverflow.com/questions/47972479/after-ruby-update-to-2-5-0-require-bundler-setup-raise-exception
 RUN cd /home/app/fedora_ingest_rails && gem update --system
 RUN cd /home/app/fedora_ingest_rails && gem install bundler
 RUN cd /home/app/fedora_ingest_rails && bundle install -V --without test development
@@ -38,6 +37,6 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 FROM production AS development
 
 RUN cd /home/app/fedora_ingest_rails && rm -rfv .bundle
-RUN cd /home/app/fedora_ingest_rails && BUNDLER_WITH="development test" bundle
+RUN cd /home/app/fedora_ingest_rails && bundle -V --with test development
 # It will be linked from localhost
 RUN rm -rf /home/app/fedora_ingest_rails/*

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -22,7 +22,7 @@ module IngestJobHelper
 
     parent_uuids = []
     local_parent_and_item_repo_solr_docs_to_update = []
-    index_time = Time.now.iso8601 #make this match dateIndexed OR replace dateIndexed
+    index_time = Time.now.iso8601
 
     parent_and_item_repo_docs.each do |doc|
       doc_uuid = doc['uuid']

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -22,12 +22,14 @@ module IngestJobHelper
 
     parent_uuids = []
     local_parent_and_item_repo_solr_docs_to_update = []
-    index_time = Time.now.iso8601
+    index_time = Time.now.iso8601 #make this match dateIndexed OR replace dateIndexed
 
     parent_and_item_repo_docs.each do |doc|
       doc_uuid = doc['uuid']
       parent_uuids << doc_uuid
       local_parent_or_item_repo_solr_doc = RepoSolrDoc.find_or_create_by!(uuid: doc_uuid)
+
+      doc['dateIndexed_s'] = index_time
 
       if local_parent_or_item_repo_solr_doc.first_indexed.nil?
         doc['firstIndexed_s'] = index_time
@@ -128,6 +130,7 @@ module IngestJobHelper
       end
 
       local_repo_capture_solr_doc = RepoSolrDoc.find_or_create_by!(uuid: uuid)
+      capture_solr_doc['dateIndexed_s'] = index_time
       capture_solr_doc['firstIndexed_s'] = local_repo_capture_solr_doc&.first_indexed&.to_time&.iso8601 || index_time
       local_repo_capture_solr_docs_to_update << local_repo_capture_solr_doc if local_repo_capture_solr_doc.first_indexed.nil?
 

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -22,7 +22,7 @@ module IngestJobHelper
 
     parent_uuids = []
     local_parent_and_item_repo_solr_docs_to_update = []
-    index_time = Time.now.iso8601
+    index_time = Time.now.iso8601(3)
 
     parent_and_item_repo_docs.each do |doc|
       doc_uuid = doc['uuid']
@@ -35,7 +35,7 @@ module IngestJobHelper
         doc['firstIndexed_s'] = index_time
         local_parent_and_item_repo_solr_docs_to_update << local_parent_or_item_repo_solr_doc
       else
-        doc['firstIndexed_s'] = local_parent_or_item_repo_solr_doc.first_indexed.to_time.strftime('%Y-%m-%d %H:%M:%S.%3N')
+        doc['firstIndexed_s'] = local_parent_or_item_repo_solr_doc.first_indexed.to_time.iso8601(3)
       end
     end
 
@@ -131,7 +131,7 @@ module IngestJobHelper
 
       local_repo_capture_solr_doc = RepoSolrDoc.find_or_create_by!(uuid: uuid)
       capture_solr_doc['dateIndexed_s'] = index_time
-      capture_solr_doc['firstIndexed_s'] = local_repo_capture_solr_doc&.first_indexed&.to_time&.strftime('%Y-%m-%d %H:%M:%S.%3N') || index_time
+      capture_solr_doc['firstIndexed_s'] = local_repo_capture_solr_doc&.first_indexed&.to_time&.iso8601(3) || index_time
       local_repo_capture_solr_docs_to_update << local_repo_capture_solr_doc if local_repo_capture_solr_doc.first_indexed.nil?
 
       repo_solr.add_docs_to_solr(capture_solr_doc)

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -35,7 +35,7 @@ module IngestJobHelper
         doc['firstIndexed_s'] = index_time
         local_parent_and_item_repo_solr_docs_to_update << local_parent_or_item_repo_solr_doc
       else
-        doc['firstIndexed_s'] = local_parent_or_item_repo_solr_doc.first_indexed.to_time.iso8601
+        doc['firstIndexed_s'] = local_parent_or_item_repo_solr_doc.first_indexed.to_time.strftime('%Y-%m-%d %H:%M:%S.%3N')
       end
     end
 
@@ -131,7 +131,7 @@ module IngestJobHelper
 
       local_repo_capture_solr_doc = RepoSolrDoc.find_or_create_by!(uuid: uuid)
       capture_solr_doc['dateIndexed_s'] = index_time
-      capture_solr_doc['firstIndexed_s'] = local_repo_capture_solr_doc&.first_indexed&.to_time&.iso8601 || index_time
+      capture_solr_doc['firstIndexed_s'] = local_repo_capture_solr_doc&.first_indexed&.to_time&.strftime('%Y-%m-%d %H:%M:%S.%3N') || index_time
       local_repo_capture_solr_docs_to_update << local_repo_capture_solr_doc if local_repo_capture_solr_doc.first_indexed.nil?
 
       repo_solr.add_docs_to_solr(capture_solr_doc)

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ development:
   <<: *default
   database: <%= ENV.fetch('DATABASE_NAME') { 'fedora_ingest_rails_development' } %>
   username: <%= ENV.fetch('DATABASE_USER_NAME') { 'postgres' } %>
-  password: <%= ENV.fetch('DATABASE_USER_NAME') { 'mypassword' } %>
+  password: <%= ENV.fetch('DATABASE_PASSWORD') { 'mypassword' } %>
   host: <%= ENV.fetch('DATABASE_HOST') { 'postgres' } %>
   reconnect: true
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,25 +7,26 @@ default: &default
 
 development:
   <<: *default
-  host: postgres
-  database: fedora_ingest_rails_development
-  username: postgres
-  password: mypassword
+  database: <%= ENV.fetch('DATABASE_NAME') { 'fedora_ingest_rails_development' } %>
+  username: <%= ENV.fetch('DATABASE_USER_NAME') { 'postgres' } %>
+  password: <%= ENV.fetch('DATABASE_USER_NAME') { 'mypassword' } %>
+  host: <%= ENV.fetch('DATABASE_HOST') { 'postgres' } %>
+  reconnect: true
 
 image_filestore:
   adapter: mysql2
-  host:     <%= ENV.fetch("IMAGE_FILESTORE_DATABASE_HOST") {'localhost'} %>
-  database: <%= ENV.fetch("IMAGE_FILESTORE_DATABASE_NAME") %>
-  username: <%= ENV.fetch("IMAGE_FILESTORE_DATABASE_USER") %>
-  password: <%= ENV.fetch("IMAGE_FILESTORE_DATABASE_PASSWORD") {nil} %>
+  host:     <%= ENV.fetch('IMAGE_FILESTORE_DATABASE_HOST') { 'localhost' } %>
+  database: <%= ENV.fetch('IMAGE_FILESTORE_DATABASE_NAME') %>
+  username: <%= ENV.fetch('IMAGE_FILESTORE_DATABASE_USER') %>
+  password: <%= ENV.fetch('IMAGE_FILESTORE_DATABASE_PASSWORD') { nil } %>
   reconnect: true
 
 ami_filestore:
   adapter: mysql2
-  host:     <%= ENV.fetch("AMI_FILESTORE_DATABASE_HOST") {'localhost'} %>
-  database: <%= ENV.fetch("AMI_FILESTORE_DATABASE_NAME") %>
-  username: <%= ENV.fetch("AMI_FILESTORE_DATABASE_USER") %>
-  password: <%= ENV.fetch("AMI_FILESTORE_DATABASE_PASSWORD") {nil} %>
+  host:     <%= ENV.fetch('AMI_FILESTORE_DATABASE_HOST') { 'localhost' } %>
+  database: <%= ENV.fetch('AMI_FILESTORE_DATABASE_NAME') %>
+  username: <%= ENV.fetch('AMI_FILESTORE_DATABASE_USER') %>
+  password: <%= ENV.fetch('AMI_FILESTORE_DATABASE_PASSWORD') { nil } %>
   reconnect: true
 
 # The ENV VARs are for Dockerized localhost, the default Procs are for Travis

--- a/db/migrate/20230412181309_create_repo_solr_docs.rb
+++ b/db/migrate/20230412181309_create_repo_solr_docs.rb
@@ -2,7 +2,7 @@ class CreateRepoSolrDocs < ActiveRecord::Migration[5.2]
   def up
     create_table :repo_solr_docs do |t|
       t.string :uuid, limit: 36
-      t.timestamp :first_indexed, precision: 3
+      t.timestamp :first_indexed
     end
     add_index :repo_solr_docs, :uuid, unique: true
   end

--- a/db/migrate/20230412181309_create_repo_solr_docs.rb
+++ b/db/migrate/20230412181309_create_repo_solr_docs.rb
@@ -2,7 +2,7 @@ class CreateRepoSolrDocs < ActiveRecord::Migration[5.2]
   def up
     create_table :repo_solr_docs do |t|
       t.string :uuid, limit: 36
-      t.timestamp :first_indexed
+      t.timestamp :first_indexed, precision: 3
     end
     add_index :repo_solr_docs, :uuid, unique: true
   end

--- a/spec/helpers/ingest_job_helper_spec.rb
+++ b/spec/helpers/ingest_job_helper_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'IngestHelper', type: :helper do
     context 'the indexing time is known' do
       before { allow(Time).to receive(:now).and_return(known_datetime) }
 
-      let(:known_datetime) { DateTime.parse('2023-04-13 15:07:25 +0000') }
+      let(:known_datetime) { DateTime.parse('2023-05-22T20:22:29.472+00:00') }
 
       let(:expected_parent_and_item_repo_solr_docs) { [parent_or_item_repo_solr_doc_1, parent_or_item_repo_solr_doc_2] }
       let(:parent_or_item_repo_solr_doc_1) {

--- a/spec/helpers/ingest_job_helper_spec.rb
+++ b/spec/helpers/ingest_job_helper_spec.rb
@@ -117,12 +117,14 @@ RSpec.describe 'IngestHelper', type: :helper do
       let(:parent_or_item_repo_solr_doc_1) {
         {
           'firstIndexed_s' => known_datetime,
+          'dateIndexed_s' => known_datetime,
           'uuid' => repo_doc_1['uuid']
         }
       }
       let(:parent_or_item_repo_solr_doc_2) {
         {
           'firstIndexed_s' => known_datetime,
+          'dateIndexed_s' => known_datetime,
           'uuid' => repo_doc_2['uuid']
         }
       }
@@ -130,6 +132,7 @@ RSpec.describe 'IngestHelper', type: :helper do
       let(:expected_capture_solr_doc_1) {
         {
           'firstIndexed_s' => known_datetime,
+          'dateIndexed_s' => known_datetime,
           'highResLink' => nil,
           :uuid => capture_1[:uuid]
         }
@@ -137,12 +140,13 @@ RSpec.describe 'IngestHelper', type: :helper do
       let(:expected_capture_solr_doc_2) {
         {
           'firstIndexed_s' => known_datetime,
+          'dateIndexed_s' => known_datetime,
           'highResLink' => nil,
           :uuid => capture_2[:uuid]
         }
       }
 
-      it 'adds firstIndexed_s to all the repo solr docs' do
+      it 'adds firstIndexed_s and dateIndexed_s to all the repo solr docs' do
         expect(mock_repo_solr_client).to receive(:add_docs_to_solr).with(expected_parent_and_item_repo_solr_docs).once
         expect(mock_repo_solr_client).to receive(:add_docs_to_solr).with(expected_capture_solr_doc_1).once
         expect(mock_repo_solr_client).to receive(:add_docs_to_solr).with(expected_capture_solr_doc_2).once


### PR DESCRIPTION
## Jira Tickets ##
[Create new field to accurately record first index date in repo api](https://jira.nypl.org/browse/DR-2269)

## Things Done ##
- Revised the Dockerfile to include rspec gems for local development and set the project home directory correctly
- Made ingest overwrite the value of `dateIndexed_s` to ensure that it matches with `firstIndexed_s`
- Format `first_indexed` to millisecond precision when retrieving it from the database

## How to Test ##
- Post an item uuid and test_mode: true to fedora ingest.
- Retrieve the document from solr by uuid. It should have been posted successfully. 
- Repost the same item. The `firstIndexed_s` timestamps of its captures should still appear to millisecond precision.

Here are step by step instructions:

### Local Development ###
- rebuild your fedora ingest application to add recent dependencies: `docker-compose build`
- Configure your application to use some QA "stuff" (you'll want to revert these changes when you're done testing)
```
# these connections are not used locally _or_ in qa but can help prove out that fedora ingest test mode works without them
FEDORA_USERNAME=fedoraAdmin #qa 
FEDORA_PASSWORD='COWwNBsuHUWmliEDNZUpvIRGQVXhKprTK7hcxMRLkw8ZctoSUj' #qa 
FEDORA_URL='http://qa01-fmaster.repo.nypl.org:8080/fedora' #qa 

IMAGE_FILESTORE_DATABASE_HOST='prod.mysql.nypl.org' #qa 
IMAGE_FILESTORE_DATABASE_NAME=archive #qa 
IMAGE_FILESTORE_DATABASE_USER=digital_read #qa 
IMAGE_FILESTORE_DATABASE_PASSWORD=d1g1t@l #qa 

AMI_FILESTORE_DATABASE_HOST='' #qa 
AMI_FILESTORE_DATABASE_NAME='' #qa 
AMI_FILESTORE_DATABASE_USER='' #qa
AMI_FILESTORE_DATABASE_PASSWORD=mysqlpassword #qa

MMS_URL='https://qa-metadata.nypl.org:443'

# also not used
RELS_EXT_SOLR_URL='http://qa01-solr.repo.nypl.org:8080/solr-3.5/repoRels' #qa
RELS_EXT_USERNAME=solradmin #qa
RELS_EXT_PASSWORD='999][lEvels' #qa

REPO_SOLR_URL=http://10.225.131.109:8983/solr/repoapi
```
- bring up your app with `docker-compose up` and in another tab do `docker-compose run webapp bash`
- You should now be able to do `RAILS_ENV=test bundle exec rspec` and the rspecs will run without having to do anything else
- in your webapp session, cd to /logs and `tail -f development.log`
- Open postman and do a post to http://localhost:3000/ingest_requests with these properties:
    - Add Header `Content-Type: application/json`
    - Add Body -> raw 
```
{
    "uuids": ["14b44ac0-c08a-0134-67c6-00505686a51c"],
    "test_mode": true
}
```
   - NB: please swap out item uuid as you want but ensure that the item is indexed already - for example: `http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%2214b44ac0-c08a-0134-67c6-00505686a51c%22)))`
- Post the post. You should get back a 201 Created with an empty body
- Check the development logs. There should be no errors and the Delayed Worker should have worked off the existing job successfully.
- Check out `http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%2214b44ac0-c08a-0134-67c6-00505686a51c%22)))` (or whatever your doc is). It should have an updated `firstIndexed_s` value based on the time you posted (e.g. `"firstIndexed_s":["2023-04-14T20:46:02+00:00"]`). Moreover, `dateIndexed_s` should match this value.
- Post the same request again any number of times. These should all succeed, but the value of firstIndexed_s should not update on the doc. In addition, it should appear to miliesecond precision now.

### QA ###
- Acccessinate at http://nypl-digital-dev.nypl.org/index.php
- Open postman and do a post to https://qa-fedora-ingestor.nypl.org/ingest_requests with these properties:
    - Add Header `Content-Type: application/json`
    - Add Body -> raw 
```
{
    "uuids": ["14b44ac0-c08a-0134-67c6-00505686a51c"],
    "test_mode": true
}
```
   - NB: please swap out item uuid as you want but ensure that the item is indexed already - for example: http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%2214b44ac0-c08a-0134-67c6-00505686a51c%22)))
   - Check out http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%2214b44ac0-c08a-0134-67c6-00505686a51c%22))) (or whatever your doc is). It should have an updated `firstIndexed_s` value based on the time you posted (e.g. `"firstIndexed_s":["2023-05-22T20:21:36.790+00:00"]]`). Moreover, `dateIndexed_s` should match this value.
   - Post the same request again any number of times. These should all succeed, but the value of firstIndexed_s should not update on the doc.  In addition, it should appear to miliesecond precision now.
  