### PR TITLE
DR-2370 add changelog endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Accurately record first index date in repo api. (DR-2269)
+- Create changelog endpoint. (DR-2378)
 
 ### Fixed
 - Removed hierarchicalgeographic_mtxt from repoapi docs. (DR-2206)

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'mysql2', '~> 0.4.5' # used to connect to Filestore Databases
 gem 'net-http-digest_auth', '~> 1.4.1'
 gem 'nypl_log_formatter', '~> 0.1.2'
+gem 'redcarpet'
 gem 'rsolr', '~> 1.0.10'
 gem 'rsolr-ext', '~> 1.0.3'
 gem 'rubydora', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (13.0.3)
+    redcarpet (3.6.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -261,6 +262,7 @@ DEPENDENCIES
   pry (~> 0.11.3)
   puma (~> 4.3)
   rails (~> 5.2.4)
+  redcarpet
   rsolr (~> 1.0.10)
   rsolr-ext (~> 1.0.3)
   rspec-rails (~> 3.7, >= 3.7.2)

--- a/app/controllers/changelog_controller.rb
+++ b/app/controllers/changelog_controller.rb
@@ -1,0 +1,12 @@
+class ChangelogController < ApplicationController
+  layout false
+  http_basic_authenticate_with name: "admin", password: "speakingofchanges"
+
+  def index
+    changelog_path = Rails.root.join('CHANGELOG.md')
+    changelog_contents = File.read(changelog_path)
+    html_renderer = Redcarpet::Render::HTML.new
+    markdown_renderer = Redcarpet::Markdown.new(html_renderer)
+    render html: markdown_renderer.render(changelog_contents).html_safe
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get 'image_filestore_entries/status/:file_id' => 'image_filestore_entries#status'
-  
+  get 'changelog' => 'changelog#index'
+
   resources :ingest_requests, only: [:create], defaults: { format: :json }
   resources :ingest_history, only: [:show], defaults: { format: :json }
   resource :stats, only: [:show], defaults: { format: :json }


### PR DESCRIPTION
## Jira Tickets ##
[Create Changelog Endpoint for Fedora Ingest](https://jira.nypl.org/browse/DR-2370)

## Things Done ##
- Added the changelog endpoint

## How to Test ##
- Go to <application_host>/changelog and enter the usual credentials. You should see the changelog.