### PR TITLE
[DR-2399] Fixing bug with mms_client json parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed exception resulting from string responses that would end up as single hashes in conversion to json. (DR-2399)
+
 ## [1.0.7] - 2023-07-05
 
 ### Removed

--- a/app/models/mms_client.rb
+++ b/app/models/mms_client.rb
@@ -295,10 +295,11 @@ class MMSClient
 
   def convert_to_json_docs(string_response)
     if string_response
-      json_docs = JSON.parse(string_response)
-      new_docs = []
-
-      json_docs.each do |json_response|
+      json_docs   = JSON.parse(string_response)
+      docs_array  = json_docs.class == Array ? json_docs : [ json_docs ]
+      new_docs    = []
+      
+      docs_array.each do |json_response|
         json_response.except!( *REMOVABLE_FIELDS )
 
         SINGLES.each do |s|

--- a/spec/models/mms_client_spec.rb
+++ b/spec/models/mms_client_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe MMSClient, type: :model do
 
   describe 'json parsing' do
     subject { @mms_client.convert_to_json_docs(test_string) }
+    
+    context 'with a valid single JSON document' do
+      let(:test_string) { "{\"uuid\":\"69ba7b30-fe6e-013b-a248-0242ac110002\"}" }
+      let(:expected_result) { [{"uuid"=>"69ba7b30-fe6e-013b-a248-0242ac110002"}] }
+
+      it 'parses the JSON document correctly' do
+        expect(subject).to eq(expected_result)
+      end
+    end
 
     context 'with erroneous arrays' do
       let(:test_hash) {


### PR DESCRIPTION
## Jira Tickets ##
- [Undefined Method except! causing some fedora ingest jobs to fail](https://jira.nypl.org/browse/DR-2399)

## Things Done ##
- Added a check to make sure we're always turning the parsed string into an array of hashes in the convert_to_json_docs method.
 
## How to Test ##
- Run `rspec ./spec/models/mms_client_spec.rb` 
- In production, we can verify that the errored jobs are progressing. 