### PR TITLE
[DR-2470] Removes captures if deleted or suppressed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed issue where parent records were not getting deleted from solr if empty. (DR-2342)
+- Fixed issue where suppressed captures were not being pulled back from solr. (DR-2470)
 
 ### Updated
 - Added additional rights statements that release high resolution permalinks (DR-2396)

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -159,10 +159,11 @@ module IngestJobHelper
       Delayed::Worker.logger.info("ingested capture #{uuid}", uuid: ingest_request.uuid)
     end
     
+    # commit changes
+    repo_solr.commit_index_changes
+    
     # sometimes captures are deleted or suppressed, and we need to pull them back
     repo_solr.delete_unseen_captures_below(ingest_request.uuid, seen_capture_uuids)
-
-    repo_solr.commit_index_changes
 
     # do not update first indexed until we successfully return from commit
     local_repo_capture_solr_docs_to_update.each { |d| d.update_attributes(first_indexed: index_time) }

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -49,9 +49,12 @@ module IngestJobHelper
     repo_solr.add_docs_to_solr(parent_and_item_repo_docs, true)
 
     local_repo_capture_solr_docs_to_update = []
+    
+    seen_capture_uuids = []
 
     mms_client.captures_for_item(ingest_request.uuid).each do |capture|
-      uuid = capture[:uuid]
+      seen_capture_uuids << capture[:uuid]
+      uuid = capture[:uuid] 
       image_id = capture[:image_id]
       pid = "uuid:#{uuid}"
 
@@ -155,6 +158,9 @@ module IngestJobHelper
 
       Delayed::Worker.logger.info("ingested capture #{uuid}", uuid: ingest_request.uuid)
     end
+    
+    # sometimes captures are deleted or suppressed, and we need to pull them back
+    repo_solr.delete_unseen_captures_below(ingest_request.uuid, seen_capture_uuids)
 
     repo_solr.commit_index_changes
 

--- a/app/models/repo_solr_client.rb
+++ b/app/models/repo_solr_client.rb
@@ -83,4 +83,54 @@ class RepoSolrClient
     @rsolr.add new_document
     @rsolr.commit
   end
+  
+  # remove all captures not updated in current run to ensure bad captures are deleted -- use wisely!
+  def delete_unseen_captures_below(item_uuid, seen_uuids)
+    return unless @rsolr
+    
+    query = 'type_s:Capture AND immediateParent_s:"' + item_uuid + '"'
+
+    # Fetch the initial response to determine the total number of results
+    resp = @rsolr.get('select', params: { q: query, rows: 0 })
+    
+    unless resp['response']
+      raise "Bad response from Solr for immediateParent_s:#{item_uuid}."
+    end
+    
+    total_results = resp['response']['numFound']
+    deletes = false
+
+    # Calculate the total pages to loop through
+    total_pages = (total_results + 249) / 250
+
+    # Initialize variables for pagination
+    page = 0
+
+    while page <= total_pages do
+      # Set the start parameter for pagination
+      start = page * 250
+  
+      # Fetch documents from Solr with pagination
+      response = @rsolr.get('select', params: { q: query, start: start, rows: 250 })
+      
+      unless response['response']
+        puts "Bad response from Solr for page #{page}. Skipping."
+        next
+      end
+
+      # Loop through the Solr response and delete if UUID not in seen_uuids
+      response['response']['docs'].each do |doc|
+        unless seen_uuids.include?(doc['uuid'])
+          puts "Deleting capture with UUID: #{doc['uuid']}"
+          @rsolr.delete_by_id(doc['uuid'])
+          deletes = true
+        end
+      end
+      
+      # commit deletes for this loop ; depending on performance we may want to adjust this to commit after x number of deletions.
+      @rsolr.commit if deletes
+      
+      page += 1
+    end
+  end
 end

--- a/app/models/repo_solr_client.rb
+++ b/app/models/repo_solr_client.rb
@@ -121,7 +121,7 @@ class RepoSolrClient
       # Loop through the Solr response and delete if UUID not in seen_uuids
       response['response']['docs'].each do |doc|
         unless seen_uuids.include?(doc['uuid'])
-          Delayed::Worker.logger.info("Deleting capture with UUID: #{doc['uuid']}", uuid: item_uuids)
+          Delayed::Worker.logger.info("Deleting capture with UUID: #{doc['uuid']}", uuid: item_uuid)
           @rsolr.delete_by_id(doc['uuid'])
           deletes = true
         end

--- a/spec/helpers/ingest_job_helper_spec.rb
+++ b/spec/helpers/ingest_job_helper_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe 'IngestHelper', type: :helper do
       allow(FedoraClient).to receive(:new).and_return(mock_fedora_client)
       allow(MMSClient).to receive(:new).and_return(mock_mms_client)
       allow(RepoSolrClient).to receive(:new).and_return(mock_repo_solr_client)
+      allow(mock_repo_solr_client).to receive(:delete_unseen_captures_below).with("MyString", ["capture_1_uuid", "capture_2_uuid"])
       allow(mock_mms_client).to receive(:repo_doc_for).with(capture_1[:uuid]).and_return(capture_1).once
       allow(mock_mms_client).to receive(:repo_doc_for).with(capture_2[:uuid]).and_return(capture_2).once
       allow(ImageFilestoreEntry).to receive(:where).and_return([image_filestore_entry])

--- a/spec/models/repo_solr_client_spec.rb
+++ b/spec/models/repo_solr_client_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe RepoSolrClient, type: :model do
     describe 'update index' do
       it 'removes the parent document if the parent will be empty once this is updated' do
         # Configure mock behavior
-        allow(solr_mock).to receive(:get).with('select', params: { q: 'uuid:uuid1' } ).and_return('response' => {'docs' => [{'uuid' => 'uuid1', 'parentUUID' => ['old_uuid1']}]})
-        allow(solr_mock).to receive(:get).with('select', params: { q: "parentUUID:\"old_uuid1\" AND type_s:Item" } ).and_return('response' => {'docs' => [{'uuid' => 'uuid1', 'parentUUID' => ['old_uuid1']}], 'numFound' => 1 })
+        allow(solr_mock).to receive(:get).with('select', params: { q: 'uuid:uuid1' } )
+          .and_return('response' => {'docs' => [{'uuid' => 'uuid1', 'parentUUID' => ['old_uuid1']}]})
+        allow(solr_mock).to receive(:get).with('select', params: { q: "parentUUID:\"old_uuid1\" AND type_s:Item" } )
+          .and_return('response' => {'docs' => [{'uuid' => 'uuid1', 'parentUUID' => ['old_uuid1']}], 'numFound' => 1 })
         allow(solr_mock).to receive(:delete_by_query)
         allow(solr_mock).to receive(:add)
         allow(solr_mock).to receive(:commit)
@@ -36,8 +38,10 @@ RSpec.describe RepoSolrClient, type: :model do
       end
       
       it 'does not remove the parent document if the parent will not be empty once this is updated' do
-        allow(solr_mock).to receive(:get).with('select', params: { q: 'uuid:uuid10' } ).and_return('response' => {'docs' => [{'uuid' => 'uuid10', 'parentUUID' => ['old_populated_uuid1']}]})
-        allow(solr_mock).to receive(:get).with('select', params: { q: "parentUUID:\"old_populated_uuid1\" AND type_s:Item" } ).and_return('response' => {'docs' => [{'uuid' => 'uuid10', 'parentUUID' => ['old_populated_uuid1']}, {'uuid' => 'uuid11', 'parentUUID' => ['old_populated_uuid1']}], 'numFound' => 2 })
+        allow(solr_mock).to receive(:get).with('select', params: { q: 'uuid:uuid10' } )
+          .and_return('response' => {'docs' => [{'uuid' => 'uuid10', 'parentUUID' => ['old_populated_uuid1']}]})
+        allow(solr_mock).to receive(:get).with('select', params: { q: "parentUUID:\"old_populated_uuid1\" AND type_s:Item" } )
+          .and_return('response' => {'docs' => [{'uuid' => 'uuid10', 'parentUUID' => ['old_populated_uuid1']}, {'uuid' => 'uuid11', 'parentUUID' => ['old_populated_uuid1']}], 'numFound' => 2 })
         allow(solr_mock).to receive(:delete_by_query)
         allow(solr_mock).to receive(:add)
         allow(solr_mock).to receive(:commit)
@@ -55,6 +59,35 @@ RSpec.describe RepoSolrClient, type: :model do
         expect(solr_mock).to have_received(:add).with(second_new_document)
         expect(solr_mock).to have_received(:commit)
       end
+      
+      it 'deletes unseen captures' do
+        allow(solr_mock).to receive(:get).with('select', params: { q: 'type_s:Capture AND immediateParent_s:"fake-item-with-suppressed-capture"', rows: 0 })
+          .and_return('response' => {'numFound' => 2, 
+                                     'docs' => []
+                                    })
+        allow(solr_mock).to receive(:get).with('select', params: { q: 'type_s:Capture AND immediateParent_s:"fake-item-with-suppressed-capture"', rows: 250, start: 0 })
+          .and_return('response' => {'numFound' => 2, 
+                                     'docs' => [{'uuid' => 'good-capture', 'immediateParent_s' => ['fake-item-with-suppressed-capture']}, 
+                                                {'uuid' => 'suppressed-capture', 'immediateParent_s' => ['fake-item-with-suppressed-capture']}]
+                                    })
+        allow(solr_mock).to receive(:get).with('select', params: { q: 'type_s:Capture AND immediateParent_s:"fake-item-with-suppressed-capture"', rows: 250, start: 250 })
+          .and_return('response' => {'numFound' => 0, 
+                                     'docs' => []
+                                    })
+        allow(solr_mock).to receive(:delete_by_id).with('good-capture')
+        allow(solr_mock).to receive(:delete_by_id).with('suppressed-capture')
+        allow(solr_mock).to receive(:commit)
+  
+        # Use the mock in the RepoSolrClient instance
+        allow(RSolr).to receive(:connect).and_return(solr_mock)
+  
+        subject.delete_unseen_captures_below('fake-item-with-suppressed-capture',['good-capture'])
+  
+        # Expect that 'delete_by_query' was called with the specific argument
+        expect(solr_mock).to_not have_received(:delete_by_id).with('good-capture')
+        expect(solr_mock).to have_received(:delete_by_id).with('suppressed-capture')
+      end
+
     end
   end
 end

--- a/spec/models/repo_solr_client_spec.rb
+++ b/spec/models/repo_solr_client_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe RepoSolrClient, type: :model do
   
         subject.delete_unseen_captures_below('fake-item-with-suppressed-capture',['good-capture'])
   
-        # Expect that 'delete_by_query' was called with the specific argument
+        # Expect that 'delete_by_id' was called with the specific argument
         expect(solr_mock).to_not have_received(:delete_by_id).with('good-capture')
         expect(solr_mock).to have_received(:delete_by_id).with('suppressed-capture')
       end


### PR DESCRIPTION
## Jira Tickets ##
[Changes in MMS not reflected on DC](https://jira.nypl.org/browse/DR-2470)

## Things Done ##
- Created new method in Repo Solr Client model to remove captures if they have not been included in current post for an item. 

## How to Test ##

### Local Development ###

Run rspecs. Here are the instructions for that: 

- rebuild your fedora ingest application to add recent dependencies: `docker-compose build`
- Configure your application to use some QA "stuff" (you'll want to revert these changes when you're done testing)
```
# these connections are not used locally _or_ in qa but can help prove out that fedora ingest test mode works without them
FEDORA_USERNAME=fedoraAdmin #qa 
FEDORA_PASSWORD=COWwNBsuHUWmliEDNZUpvIRGQVXhKprTK7hcxMRLkw8ZctoSUj #qa 
FEDORA_URL=http://qa01-fmaster.repo.nypl.org:8080/fedora #qa 

IMAGE_FILESTORE_DATABASE_HOST=prod.mysql.nypl.org #qa 
IMAGE_FILESTORE_DATABASE_NAME=archive #qa 
IMAGE_FILESTORE_DATABASE_USER=digital_read #qa 
IMAGE_FILESTORE_DATABASE_PASSWORD=d1g1t@l #qa 

AMI_FILESTORE_DATABASE_HOST='' #qa 
AMI_FILESTORE_DATABASE_NAME='' #qa 
AMI_FILESTORE_DATABASE_USER='' #qa
AMI_FILESTORE_DATABASE_PASSWORD=mysqlpassword #qa

MMS_URL=https://qa-metadata.nypl.org:443

REPO_SOLR_URL=http://10.225.133.217:8983/solr/repoapi
```
- bring up your app with `docker-compose up` and in another tab do `docker-compose run webapp bash`
- You should now be able to do `RAILS_ENV=test bundle exec rspec` and the rspecs will run without having to do anything else
- Feel free to follow additional QA steps.

### QA ###
- Acccessinate at http://nypl-digital-dev.nypl.org/index.php
- Create some fake capture records beneath a valid item uuid, via 
```
curl -X POST -H "Content-Type: application/json" -d '[
{
"uuid": "fake-bad-uuid",
"type_s": "http://uri.nypl.org/vocabulary/repository_terms#Capture",
"immediateParent_s": ["22a518c0-c6f4-012f-59b2-58d385a7bc34"]
}
]' 'http://10.225.133.217:8983/solr/repoapi/update?commit=true'
```
- Open postman and do a post to https://qa-fedora-ingestor.nypl.org/ingest_requests with these properties:
    - Add Header `Content-Type: application/json`
    - Add Body -> raw 
```
{
    "uuids": ["22a518c0-c6f4-012f-59b2-58d385a7bc34"],
    "test_mode": true
}
```
   - Check out http://10.225.133.217:8983/solr/repoapi/select?q=((%2Buuid:(%2B%22fake-bad-uuid%22))). It should be gone.
   
  - Open postman and do a post to https://qa-fedora-ingestor.nypl.org/ingest_requests with these properties:
    - Add Header `Content-Type: application/json`
    - Add Body -> raw 
```
{
    "uuids": ["c918df20-c52a-012f-8ce5-3c075448cc4b"],
    "test_mode": true
}
```
   - Check out http://10.225.133.217:8983/solr/repoapi/select?q=((%2Buuid:(%2B%22510d47da-f0be-a3d9-e040-e00a18064a99%22))). It should NOT be gone. (This is a real and valid capture uuid in QA index.)