### PR TITLE
[DR-2690] Fixing call for captures from MMS. We do not want all of them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed additional issue causing suppressed captures to be pulled in for indexing. (DR-2690)
+
 ### Added
 - Added one-off script to cleanup empty collections and containers. (DR-2557)
 

--- a/app/models/mms_client.rb
+++ b/app/models/mms_client.rb
@@ -283,7 +283,7 @@ class MMSClient
   # [{image_uuid: '123-456', image_id: '1234'}]
   def captures_for_item(uuid)
     response = []
-    api_response = make_request_for('get_captures', uuid)
+    api_response = make_request_for('get_captures', uuid, { showAll: 'false' })
     capture_nodes = Nokogiri::XML(api_response).css('capture')
 
     capture_nodes.each do |capture_node|

--- a/app/models/mms_client.rb
+++ b/app/models/mms_client.rb
@@ -283,7 +283,7 @@ class MMSClient
   # [{image_uuid: '123-456', image_id: '1234'}]
   def captures_for_item(uuid)
     response = []
-    api_response = make_request_for('get_captures', uuid, { showAll: 'true' })
+    api_response = make_request_for('get_captures', uuid)
     capture_nodes = Nokogiri::XML(api_response).css('capture')
 
     capture_nodes.each do |capture_node|

--- a/spec/models/mms_client_spec.rb
+++ b/spec/models/mms_client_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe MMSClient, type: :model do
     end
 
     it "makes a request to get an Item's Captures" do
-      expect(HTTP).to receive(:get).with('http://example.com/exports/get_captures/abc-123', params: {}) { double(code: 200) }
+      expect(HTTP).to receive(:get).with('http://example.com/exports/get_captures/abc-123', params: { showAll: 'false' }) { double(code: 200) }
       @mms_client.captures_for_item('abc-123')
     end
 

--- a/spec/models/mms_client_spec.rb
+++ b/spec/models/mms_client_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe MMSClient, type: :model do
     end
 
     it "makes a request to get an Item's Captures" do
-      expect(HTTP).to receive(:get).with('http://example.com/exports/get_captures/abc-123', params: { showAll: 'true' }) { double(code: 200) }
+      expect(HTTP).to receive(:get).with('http://example.com/exports/get_captures/abc-123', params: {}) { double(code: 200) }
       @mms_client.captures_for_item('abc-123')
     end
 


### PR DESCRIPTION
## Jira Ticket ##
[Suppressed captures are being displayed](https://jira.nypl.org/browse/DR-2690)

## Things Done ##
- Found one final (I hope) issue that was pulling in suppressed captures from MMS. 

## How to Test ##
- The problem exists within the MMSClient method, get_captures. To test the response on your own, you can run your local container, then feel free to point to production MMS (or QA, if you like, or a local copy running locally -- whichever you prefer). 
- From the running Fedora Ingest container, fire up the console, and test: 
`mms_client = MMSClient.new(mms_url: Rails.application.secrets.mms_url, user_name: Rails.application.secrets.mms_http_basic_username, password: Rails.application.secrets.mms_http_basic_password);
mms_client.captures_for_item(ANY_GIVEN_TEST_ITEM_UUID)
`
You can find the test uuid from the ticket above's information, but one example is e1b08d00-3219-0133-30ec-00505686a51c ; if you asked for captures with the original code, you would see eight. New code will return only two. But feel free to use any item uuid with suppressed captures, and the counts should match. 

## Followup Work ##
There will be a companion PR in MMS simply to post the item uuids for any item with suppressed captures. Current count puts this at about 1600 items, which should be very easy work for this app to handle. 