### PR TITLE
Fix bundler incompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
   - qa
   - nypl-dams-prod
 before_install:
-  - gem update --system 3.0.14
+  - gem update --system 3.2.3
   - gem install bundler -v '2.2.15'
 rvm:
 - 2.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
   - qa
   - nypl-dams-prod
 before_install:
-  - gem update --system
+  - gem update --system 3.0.14
   - gem install bundler -v '2.2.15'
 rvm:
 - 2.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ before_script:
 - mysql -uroot ami_filestore_test < ./db/resources/ami_filestore_schema.sql
 - mysql -uroot image_filestore_test < ./db/resources/image_filestore_schema.sql
 script:
+- gem update --system
+- gem install bundler -v '2.2.15'
+- bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
 - bundle exec rspec
 after_success:
 - provisioning/travis_ci_and_cd/build_and_push_to_ecr.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_script:
 script:
 - gem update --system
 - gem install bundler -v '2.2.15'
-- bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
-- bundle exec rspec
+- rvm use 2.6.5 do bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
+- rvm use 2.6.5 do bundle exec rspec
 after_success:
 - provisioning/travis_ci_and_cd/build_and_push_to_ecr.sh
 - provisioning/travis_ci_and_cd/ecs_deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ branches:
   only:
   - qa
   - nypl-dams-prod
+before_install:
+  - gem update --system
+  - gem install bundler -v '2.2.15'
 rvm:
 - 2.6.5
 cache: bundler
@@ -17,10 +20,7 @@ before_script:
 - mysql -uroot ami_filestore_test < ./db/resources/ami_filestore_schema.sql
 - mysql -uroot image_filestore_test < ./db/resources/image_filestore_schema.sql
 script:
-- gem update --system
-- gem install bundler -v '2.2.15'
-- rvm use 2.6.5 do bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
-- rvm use 2.6.5 do bundle exec rspec
+- bundle exec rspec
 after_success:
 - provisioning/travis_ci_and_cd/build_and_push_to_ecr.sh
 - provisioning/travis_ci_and_cd/ecs_deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ADD ./provisioning/docker_build/environment-variables.conf /etc/nginx/main.d/env
 COPY Gemfile /home/app/fedora_ingest_rails/
 COPY Gemfile.lock /home/app/fedora_ingest_rails/
 WORKDIR /home/app/fedora_ingest_rails
-RUN gem update --system
+RUN gem update --system 3.2.3
 RUN gem install bundler
 
 # Passenger Configuration & App


### PR DESCRIPTION
This PR fixes recent build issues, both in Travis and on local. The relevant warning message was:

```
Your RubyGems version (3.0.6) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`
```