### PR TITLE
DR 2789 add new datetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added one-off script to cleanup empty collections and containers. (DR-2557)
+- Added firstIndexed_dt and dateIndexed_dt to repoapi solr docs. (DR-2789)
 
 ### Updated
 - Stopped deploying to legacy environments. (DR-2661)

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -148,8 +148,6 @@ module IngestJobHelper
       capture_solr_doc['firstIndexed_s'] = first_indexed
       capture_solr_doc['firstIndexed_dt'] = format_as_solr_dt(first_indexed_plain)
 
-      puts "@JC capture solr doc: #{capture_solr_doc.inspect}"
-
       local_repo_capture_solr_docs_to_update << local_repo_capture_solr_doc if local_repo_capture_solr_doc.first_indexed.nil?
 
       # add docs to solr without checking parents this time

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -26,7 +26,6 @@ module IngestJobHelper
     local_parent_and_item_repo_solr_docs_to_update = []
     index_time_plain = Time.now
     index_time = index_time_plain.iso8601(3)
-    #index_time = Time.now.iso8601(3)
 
     parent_and_item_repo_docs.each do |doc|
       doc_uuid = doc['uuid']

--- a/app/models/mms_client.rb
+++ b/app/models/mms_client.rb
@@ -68,6 +68,7 @@ class MMSClient
   SINGLES = [
     'dateDigitized_dt',
     'dateIndexed_s',
+    'dateIndexed_dt',
     'firstInSequence',
     'firstIndexed_s',
     'highResLink',

--- a/spec/helpers/ingest_job_helper_spec.rb
+++ b/spec/helpers/ingest_job_helper_spec.rb
@@ -167,23 +167,24 @@ RSpec.describe 'IngestHelper', type: :helper do
 
       let(:known_datetime) { "2023-08-28 18:41:34 -0400" }
       let(:expected_utc_timestamp) { Time.parse(known_datetime).utc.strftime('%Y-%m-%dT%H:%M:%S.%LZ') }
+      let(:expected_dt_timestamp) { Time.parse(known_datetime).strftime('%Y-%m-%dT%H:%M:%SZ') }
 
       let(:expected_parent_and_item_repo_solr_docs) { [parent_or_item_repo_solr_doc_1, parent_or_item_repo_solr_doc_2] }
       let(:parent_or_item_repo_solr_doc_1) {
         {
           'firstIndexed_s' => expected_utc_timestamp,
-          'firstIndexed_dt' => expected_utc_timestamp,
+          'firstIndexed_dt' => expected_dt_timestamp,
           'dateIndexed_s' => expected_utc_timestamp,
-          'dateIndexed_dt' => expected_utc_timestamp,
+          'dateIndexed_dt' => expected_dt_timestamp,
           'uuid' => repo_doc_1['uuid']
         }
       }
       let(:parent_or_item_repo_solr_doc_2) {
         {
           'firstIndexed_s' => expected_utc_timestamp,
-          'firstIndexed_dt' => expected_utc_timestamp,
+          'firstIndexed_dt' => expected_dt_timestamp,
           'dateIndexed_s' => expected_utc_timestamp,
-          'dateIndexed_dt' => expected_utc_timestamp,
+          'dateIndexed_dt' => expected_dt_timestamp,
           'uuid' => repo_doc_2['uuid']
         }
       }
@@ -191,9 +192,9 @@ RSpec.describe 'IngestHelper', type: :helper do
       let(:expected_capture_solr_doc_1) {
         {
           'firstIndexed_s' => expected_utc_timestamp,
-          'firstIndexed_dt' => expected_utc_timestamp,
+          'firstIndexed_dt' => expected_dt_timestamp,
           'dateIndexed_s' => expected_utc_timestamp,
-          'dateIndexed_dt' => expected_utc_timestamp,
+          'dateIndexed_dt' => expected_dt_timestamp,
           'highResLink' => nil,
           :uuid => capture_1[:uuid]
         }
@@ -201,9 +202,9 @@ RSpec.describe 'IngestHelper', type: :helper do
       let(:expected_capture_solr_doc_2) {
         {
           'firstIndexed_s' => expected_utc_timestamp,
-          'firstIndexed_dt' => expected_utc_timestamp,
+          'firstIndexed_dt' => expected_dt_timestamp,
           'dateIndexed_s' => expected_utc_timestamp,
-          'dateIndexed_dt' => expected_utc_timestamp,
+          'dateIndexed_dt' => expected_dt_timestamp,
           'highResLink' => nil,
           :uuid => capture_2[:uuid]
         }

--- a/spec/helpers/ingest_job_helper_spec.rb
+++ b/spec/helpers/ingest_job_helper_spec.rb
@@ -172,14 +172,18 @@ RSpec.describe 'IngestHelper', type: :helper do
       let(:parent_or_item_repo_solr_doc_1) {
         {
           'firstIndexed_s' => expected_utc_timestamp,
+          'firstIndexed_dt' => expected_utc_timestamp,
           'dateIndexed_s' => expected_utc_timestamp,
+          'dateIndexed_dt' => expected_utc_timestamp,
           'uuid' => repo_doc_1['uuid']
         }
       }
       let(:parent_or_item_repo_solr_doc_2) {
         {
           'firstIndexed_s' => expected_utc_timestamp,
+          'firstIndexed_dt' => expected_utc_timestamp,
           'dateIndexed_s' => expected_utc_timestamp,
+          'dateIndexed_dt' => expected_utc_timestamp,
           'uuid' => repo_doc_2['uuid']
         }
       }
@@ -187,7 +191,9 @@ RSpec.describe 'IngestHelper', type: :helper do
       let(:expected_capture_solr_doc_1) {
         {
           'firstIndexed_s' => expected_utc_timestamp,
+          'firstIndexed_dt' => expected_utc_timestamp,
           'dateIndexed_s' => expected_utc_timestamp,
+          'dateIndexed_dt' => expected_utc_timestamp,
           'highResLink' => nil,
           :uuid => capture_1[:uuid]
         }
@@ -195,7 +201,9 @@ RSpec.describe 'IngestHelper', type: :helper do
       let(:expected_capture_solr_doc_2) {
         {
           'firstIndexed_s' => expected_utc_timestamp,
+          'firstIndexed_dt' => expected_utc_timestamp,
           'dateIndexed_s' => expected_utc_timestamp,
+          'dateIndexed_dt' => expected_utc_timestamp,
           'highResLink' => nil,
           :uuid => capture_2[:uuid]
         }

--- a/spec/helpers/ingest_job_helper_spec.rb
+++ b/spec/helpers/ingest_job_helper_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe 'IngestHelper', type: :helper do
     context 'the indexing time is known' do
       before { allow(Time).to receive(:now).and_return(Time.parse(known_datetime)) }
 
-      let(:known_datetime) { "2023-08-28 18:41:34 -0400" }
+      let(:known_datetime) { "2024-02-12 14:06:10 +0000" }
       let(:expected_utc_timestamp) { Time.parse(known_datetime).utc.strftime('%Y-%m-%dT%H:%M:%S.%LZ') }
       let(:expected_dt_timestamp) { Time.parse(known_datetime).strftime('%Y-%m-%dT%H:%M:%SZ') }
 


### PR DESCRIPTION
## Jira Tickets ##
- [Provide data for new fields firstIndexed and dateIndexed datetimes](https://jira.nypl.org/browse/DR-2789)

## Things Done ##
- Add datetime values for firstIndexed_dt and dateIndexed_dt to repoapi solr docs

## How to Test ##
- Post an item uuid and test_mode: true to fedora ingest.
- Retrieve the document from solr by uuid. It should have been posted successfully. In addition, it should have values for `firstIndexed_dt` and `dateIndexed_dt`. The same should be true of its approved front-door captures.

Here are step by step instructions:

### Local Development ###
- bring up your app with `docker-compose up` and in another tab do `docker-compose run webapp bash`
- You should now be able to do `RAILS_ENV=test bundle exec rspec` and the rspecs will pass
- Bring down the containers again.
- Get on the VPN
- Configure your application to use some QA "stuff" (you'll want to revert these changes when you're done testing)
```
FEDORA_USERNAME=fedoraAdmin #qa 
FEDORA_PASSWORD='COWwNBsuHUWmliEDNZUpvIRGQVXhKprTK7hcxMRLkw8ZctoSUj' #qa 
FEDORA_URL='http://qa01-fmaster.repo.nypl.org:8080/fedora' #qa 

IMAGE_FILESTORE_DATABASE_HOST='prod.mysql.nypl.org' #qa 
IMAGE_FILESTORE_DATABASE_NAME=archive #qa 
IMAGE_FILESTORE_DATABASE_USER=digital_read #qa 
IMAGE_FILESTORE_DATABASE_PASSWORD=d1g1t@l #qa 

AMI_FILESTORE_DATABASE_HOST='' #qa 
AMI_FILESTORE_DATABASE_NAME='' #qa 
AMI_FILESTORE_DATABASE_USER='' #qa
AMI_FILESTORE_DATABASE_PASSWORD=mysqlpassword #qa

MMS_URL='https://qa-metadata.nypl.org:443'

# also not used
RELS_EXT_SOLR_URL='http://qa01-solr.repo.nypl.org:8080/solr-3.5/repoRels' #qa
RELS_EXT_USERNAME=solradmin #qa
RELS_EXT_PASSWORD='999][lEvels' #qa

REPO_SOLR_URL=http://10.225.131.109:8983/solr/repoapi
```
- Bring up the application
- in your webapp session, cd to /logs and `tail -f development.log`
- Open postman and do a post to http://localhost:3000/ingest_requests with these properties:
    - Add Header `Content-Type: application/json`
    - Add Body -> raw 
```
{
    "uuids": ["2214b44ac0-c08a-0134-67c6-00505686a51c"],
    "test_mode": true
}
```
- NB: please swap out item uuid as you want but ensure that the item is indexed already
- Post the post. You should get back a 201 Created with an empty body
- Check the development logs. There should be no errors and the Delayed Worker should have worked off the existing job successfully.
- Check out `http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%22221b49a0-ad5e-0137-e775-2785dcbe2934%22)))` (or whatever your doc is). It should have a  `firstIndexed_dt` value similar to the `firstIndexed_s` value (e.g. `"2024-02-09T17:35:09Z"`). Moreover, `dateIndexed_dt` should be present based on when you posted.

### QA ###
- Acccessinate at http://nypl-digital-dev.nypl.org/index.php
- Open postman and do a post to https://qa-fedora-ingestor.nypl.org/ingest_requests with these properties:
    - Add Header `Content-Type: application/json`
    - Add Body -> raw 
```
{
    "uuids": ["14b44ac0-c08a-0134-67c6-00505686a51c"],
    "test_mode": true
}
```
- NB: please swap out item uuid as you want but ensure that the item is indexed already - for example: http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%2214b44ac0-c08a-0134-67c6-00505686a51c%22)))
- Check out `http://10.225.131.109:8983/solr/repoapi/select?q=((%2Buuid:(%2B%22221b49a0-ad5e-0137-e775-2785dcbe2934%22)))` (or whatever your doc is). It should have a  `firstIndexed_dt` value similar to the `firstIndexed_s` value (e.g. `"2024-02-09T17:35:09Z"`). Moreover, `dateIndexed_dt` should be present based on when you posted.
  