### PR TITLE
[DR-3114] Script for populating rootCollectionUUID_string

### DIFF
--- a/scripts/one-offs/DR-3114-add-root-collection-uuid-string/add_root_collection_uuid_string.rb
+++ b/scripts/one-offs/DR-3114-add-root-collection-uuid-string/add_root_collection_uuid_string.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: false
+
+# This comes from https://jira.nypl.org/browse/DR-3114
+
+# We need to update all records in the repoapi index to include the rootCollectionUUID_string field value, copied from rootCollectionUUID_s.
+
+# How to run (adjust solr url to the solr of your choice): ruby ./scripts/one-offs/DR-3114-add-root-collection-uuid-string/add_root_collection_uuid_string.rb http://10.225.133.217:8983/solr/repoapi
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'config', 'environment'))
+require 'rsolr'
+
+solr = RSolr.connect url: ARGV[0]
+
+solr_params = {
+    q: 'mainTitle:[* TO *] AND -rootCollectionUUID_string:[* TO *]',
+    rows: 500
+}
+
+response = solr.get 'select', params: solr_params
+
+total_found = response['response']['numFound']
+total_count = 0
+
+while total_count <= total_found do
+  update_json = []
+  response = solr.get 'select', params: solr_params
+  response['response']['docs'].each do |doc|
+    puts doc['uuid']
+    update_json << { uuid: doc['uuid'],
+    "dateIndexed_s" => { set: RepoSolrDoc.get_datetime_s },
+    "dateIndexed_dt" => { set: RepoSolrDoc.get_datetime_dt } }
+  end
+      
+  solr.update(data: update_json.to_json, headers: { 'Content-Type' => 'application/json' })
+  solr.commit
+  total_count += update_json.count
+  puts "Updated #{total_count} of #{total_found} documents."
+  puts "Going back for more ..."
+
+  begin
+    solr = RSolr.connect url: ARGV[0]
+  rescue Exception => e
+    # Refresh the solr connction in case of timeouts
+    random_sleep = rand(1..5)
+    sleep(random_sleep)
+    solr = RSolr.connect url: ARGV[0]
+  end 
+end
+
+puts "Script finished!"

--- a/scripts/one-offs/DR-3114-add-root-collection-uuid-string/add_root_collection_uuid_string.rb
+++ b/scripts/one-offs/DR-3114-add-root-collection-uuid-string/add_root_collection_uuid_string.rb
@@ -12,8 +12,8 @@ require 'rsolr'
 solr = RSolr.connect url: ARGV[0]
 
 solr_params = {
-    q: 'mainTitle:[* TO *] AND -rootCollectionUUID_string:[* TO *]',
-    rows: 500
+    q: 'rootCollectionUUID_s:[* TO *] AND -rootCollectionUUID_string:[* TO *]',
+    rows: 1000
 }
 
 response = solr.get 'select', params: solr_params


### PR DESCRIPTION
## JIRA tickets:
- [Add new rootCollectionUUID_string to all repo api records](https://newyorkpubliclibrary.atlassian.net/browse/DR-3114)

## Things Done:
- Created a script to add rootCollectionUUID_string to all records in Repo API solr core. 

## How to Test:
- From root of app, run `ruby ./scripts/one-offs/DR-3114-add-root-collection-uuid-string/add_root_collection_uuid_string.rb http://10.225.133.217:8983/solr/repoapi` (or modify to use solr of your choice). It takes two days to fully run, but you should see some updates. 
