### PR TITLE
[DR-3425] New additions for containsUnrestrictedMaterial.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Added
+- Added method to add containsUnrestrictedMaterial to solr docs. (DR-3425)
+
 ## [3.1.0] - 2025-03-12
 
 ### Removed

--- a/app/models/repo_solr_client.rb
+++ b/app/models/repo_solr_client.rb
@@ -142,6 +142,15 @@ class RepoSolrClient
         nypl_conditions || onsite_conditions
       end
       update_hash["containsOnSiteMaterial"] = onsite_material
+      
+      # Set containsUnrestrictedMaterial
+      unrestriced_material = representative_docs.any? do |doc|
+        unrestricted_conditions = doc["use_rtxt_s"]&.include?("Can be displayed on NYPL premises") &&
+                                  doc["use_rtxt_s"]&.include?("Can be used on NYPL website") &&
+                                  !doc["useRestriction_rtxt_s"]&.any? { |r| NYPL_LOCATIONS.include?(r) }
+        unrestricted_conditions
+      end
+      update_hash["containsUnrestrictedMaterial"] = unrestriced_material
   
       # Set imageID_string via imageID (it's a copyfield)
       capture = representative_docs.find do |doc|
@@ -201,8 +210,14 @@ class RepoSolrClient
         fl: "uuid,parentUUID,use_rtxt_s",
         rows: 1
       })["response"]["docs"]
+      
+      unrestricted_child = @rsolr.get("select", params: {
+        q: "parentUUID:\"#{uuid}\" AND use_rtxt_s:\"Can be displayed on NYPL premises\" AND use_rtxt_s:\"Can be used on NYPL website\" AND -useRestriction_rtxt_s:(#{NYPL_LOCATIONS.map { |loc| "\"#{loc}\"" }.join(" OR ")})",
+        fl: "uuid,parentUUID,use_rtxt_s",
+        rows: 1
+      })["response"]["docs"]
 
-      [capture, av_child, onsite_child_with_location, onsite_child_without_location].flatten
+      [capture, av_child, onsite_child_with_location, onsite_child_without_location, unrestricted_child].flatten
     end
   end
 

--- a/spec/models/repo_solr_client_spec.rb
+++ b/spec/models/repo_solr_client_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe RepoSolrClient, type: :model do
         expect(item_update["numItems_s"]).to eq(1)
         expect(item_update["containsAVMaterial"]).to eq(true)
         expect(item_update["containsOnSiteMaterial"]).to eq(false)
+        expect(item_update["containsUnrestrictedMaterial"]).to eq(false)
         expect(item_update["imageID"]).to eq("image1")
       end
     end


### PR DESCRIPTION
This adds some code to add containsUnrestrictedMaterial boolean to collections, containers, and items. 

The logic should be TRUE if there are ANY child items included that: 

- Have no location restrictions
- Can be used on the NYPL website
- Can be displayed on NYPL premises

To test run rspecs and / or run the following from the container: 

uuid = UUID_OF_YOUR_CHOICE
solr = RSolr.connect url: ENV['REPO_SOLR_URL']
resp = solr.get 'select', params: { q: "uuid:#{uuid}"}
docs = resp["response"]["docs"]
repo = RepoSolrClient.new
repo.update_key_fields(docs)

After running this, you should see a boolean value set for `containsUnrestrictedMaterial` . 

Examples of uuids and expected results: 

* Bhutan collection of videos, uuid: 6e78bb70-0d19-0131-2cea-3c075448cc4b , should evaluate to true, as the videos are unrestricted. 
* Lou Reed collection (uuid: dba41b30-0ae6-0137-bfb0-4fa251ecd76a) should evaluate to true as well, because it does have unrestricted items, HOWEVER subseries I (uuid: 53301ef0-0ae7-0137-5f69-0df412394b3e) should not as all its children are restricted. 