### PR TITLE
[DR-3923] Add support for hocr

### DIFF
--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -45,8 +45,11 @@ module IngestJobHelper
       end
     end
 
-    # magic uuid for our one and only oral history collection. TODO:     Make this more universal. KAK - Sept 20 2021
-    in_oral_history_collection = parent_uuids.include?('da4687f0-cc71-0130-fb40-58d385a7b928')
+    ocr_collection_uuids = [
+      "da4687f0-cc71-0130-fb40-58d385a7b928",  # Oral History Collection
+      "9ea5d5b0-1117-0132-7932-58d385a7b928",  # Green Books Collection
+    ]
+    is_ocr_collection = (parent_uuids & ocr_collection_uuids).any?
 
     # add docs to solr, setting the flag to check the old parents for existence.
     repo_solr = RepoSolrClient.new
@@ -93,15 +96,22 @@ module IngestJobHelper
         capture_solr_doc['highResLink'] = nil # unpublishes the link if it exists.
       end
 
-      if in_oral_history_collection
-        mets_alto = S3Client.new.mets_alto_for(uuid)
-        capture_solr_doc['mets_alto'] = mets_alto
-        capture_solr_doc['hasOCR'] = capture_solr_doc['mets_alto'].present?
+      if is_ocr_collection
+        ocr_content = S3Client.new.ocr_for(uuid)
 
-        # Get the plain text from the alto.
-        ndoc = Nokogiri::XML(mets_alto)
-        plain_text = ndoc.xpath('//String').collect { |s| s.at('@CONTENT').text }.join(" ")
-        capture_solr_doc['captureText_ocrtext'] = plain_text
+        # Get the plain text from the ocr content
+        if not ocr_content.nil?
+          if ocr_content.include?("<alto>")
+            capture_solr_doc['mets_alto'] = ocr_content
+            capture_solr_doc['hasOCR'] = capture_solr_doc['mets_alto'].present?
+            capture_solr_doc['captureText_ocrtext'] = Nokogiri::XML(ocr_content).xpath('//String').collect { |s| s.at('@CONTENT').text }.join(" ")
+
+          elsif ocr_content.include?("</html>")
+            capture_solr_doc['hocr'] = ocr_content
+            capture_solr_doc['hasOCR'] = capture_solr_doc['hocr'].present?
+            capture_solr_doc['captureText_ocrtext'] = Nokogiri::HTML(ocr_content).xpath('//*[local-name()="span" and @class="ocrx_word"]').collect { |s| s.text }.join(" ").squish
+          end
+        end
       end
 
       local_repo_capture_solr_doc = RepoSolrDoc.find_or_create_by!(uuid: uuid)

--- a/app/models/s3_client.rb
+++ b/app/models/s3_client.rb
@@ -5,26 +5,32 @@ class S3Client
     @s3 ||= Aws::S3::Client.new(region: (ENV['AWS_REGION'] || 'us-east-1'), access_key_id: ENV['AWS_ACCESS_KEY_ID'], secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
   end
 
-  def mets_alto_for(uuid)
+  def ocr_for(uuid)
     begin
-      response = @s3.get_object(bucket: ENV['S3_BUCKET_NAME'], key: "mets_altos/#{uuid}.xml")
-      raw_xml = response&.body&.read
+      response = @s3.get_object(bucket: ENV['S3_BUCKET_NAME'], key: "ocr/#{uuid}")
+      raw_text = response&.body&.read
     rescue Exception => e
-      puts "mets alto could not be retrieved for uuid: #{uuid} because #{e}"
+      puts "ocr could not be retrieved for uuid: #{uuid} because #{e}"
     end
 
-    return nil unless raw_xml
+    return nil unless raw_text
 
-    mets_alto_doc = Nokogiri::XML(raw_xml)
-    mets_alto_doc.remove_namespaces!
-    mets_alto = mets_alto_doc.to_xml
-                             .to_s
-                             .squish # remove extra whitespace
-                             .gsub("<?xml version=\"1.0\" standalone=\"no\"?>\n", '')
-                             .gsub(' schemaLocation="http://schema.ccs-gmbh.com/ALTO alto.xsd"','')
-                             .gsub('> <','><') # remove single whitespaces between xml tags
-                             .gsub("\n",'')
-                             .gsub("\t",'')
-    mets_alto
+    if raw_text.include?("<alto>")
+      mets_alto_doc = Nokogiri::XML(raw_text)
+      mets_alto_doc.remove_namespaces!
+      mets_alto = mets_alto_doc.to_xml
+                              .to_s
+                              .squish # remove extra whitespace
+                              .gsub("<?xml version=\"1.0\" standalone=\"no\"?>\n", '')
+                              .gsub(' schemaLocation="http://schema.ccs-gmbh.com/ALTO alto.xsd"','')
+                              .gsub('> <','><') # remove single whitespaces between xml tags
+                              .gsub("\n",'')
+                              .gsub("\t",'')
+      mets_alto
+    elsif raw_text.include?("</html>")
+      hocr_doc = Nokogiri::HTML(raw_text)
+      hocr_doc = hocr_doc.to_html.to_s.squish
+      hocr_doc
+    end
   end
 end

--- a/spec/helpers/ingest_job_helper_spec.rb
+++ b/spec/helpers/ingest_job_helper_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'IngestHelper', type: :helper do
 
     context 'a repo doc uuid is in the oral history collection' do
       let(:repo_doc_1) { { 'uuid' => 'da4687f0-cc71-0130-fb40-58d385a7b928' } }
-      let(:mock_s3_client) { double('s3_client', :mets_alto_for => mets_alto) }
+      let(:mock_s3_client) { double('s3_client', :ocr_for => mets_alto) }
       let(:mets_alto) { "<?xml version=\"1.0\"?><alto><String CONTENT=\"ADrLPH\" ID=\"St_1.1.1.3\" HPOS=\"2536\" VPOS=\"1400\" HEIGHT=\"140\" WIDTH=\"700\" STYLEREFS=\"Style_1\" WC=\"7.3\" CC=\"007000\"/></alto>" }
 
       let(:parent_or_item_repo_solr_doc_1_partial) { { 'uuid' => repo_doc_1['uuid'] } }

--- a/spec/models/s3_client_spec.rb
+++ b/spec/models/s3_client_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe S3Client, type: :model do
   before { allow(Aws::S3::Client).to receive(:new).and_return(mock_aws_s3_client) }
   let(:mock_aws_s3_client) { double('aws_s3_client', :get_object => mock_aws_s3_response) }
 
-  describe '#mets_alto_for' do
-    subject { S3Client.new.mets_alto_for(uuid) }
+  describe '#ocr_for' do
+    subject { S3Client.new.ocr_for(uuid) }
     let(:uuid) { 'some_uuid' }
 
     context 'the mets alto gets returned' do
@@ -17,6 +17,17 @@ RSpec.describe S3Client, type: :model do
       let(:expected_return_value) { '<?xml version="1.0"?><alto><String CONTENT="ADrLPH" ID="St_1.1.1.3" HPOS="2536" VPOS="1400" HEIGHT="140" WIDTH="700" STYLEREFS="Style_1" WC="7.3" CC="007000"/></alto>' }
 
       it 'returns the expected unescaped mets alto string' do
+        expect(subject).to eq(expected_return_value)
+      end
+    end
+
+    context 'the hocr gets returned' do
+      let(:mock_aws_s3_response) { double('aws_s3_response', :body => mock_aws_s3_response_body) }
+      let(:mock_aws_s3_response_body) { double('aws_s3_response_body', :read => hocr) }
+      let(:hocr) { "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"><html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\"><head><title></title><meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\" /><meta name='ocr-system' content='tesseract 3.04.00' /><meta name='ocr-capabilities' content='ocr_page ocr_carea ocr_par ocr_line ocrx_word'/></head><body><div class='ocr_page' id='page_1' title='image \"./1962/5215078g.jpg\"; bbox 0 0 3041 4044; ppageno 0'><div class='ocr_carea' id='block_1_1' title=\"bbox 0 0 532 404\"><p class='ocr_par' dir='ltr' id='par_1_1' title=\"bbox 0 0 532 404\"><span class='ocr_line' id='line_1_1' title=\"bbox 0 0 532 404; baseline 0 3640\"><span class='ocrx_word' id='word_1_1' title='bbox 0 0 532 404; x_wconf 95' lang='eng' dir='ltr'></span></span></p></div><div class='ocr_carea' id='block_1_2' title=\"bbox 1249 425 1777 493\"><p class='ocr_par' dir='ltr' id='par_1_2' title=\"bbox 1249 425 1777 493\"><span class='ocr_line' id='line_1_2' title=\"bbox 1249 425 1777 493; baseline 0 -12\"><span class='ocrx_word' id='word_1_2' title='bbox 1249 425 1409 483; x_wconf 91' lang='eng' dir='ltr'>New</span><span class='ocrx_word' id='word_1_3' title='bbox 1440 426 1604 482; x_wconf 88' lang='eng' dir='ltr'><strong>York</strong></span><span class='ocrx_word' id='word_1_4' title='bbox 1635 425 1777 493; x_wconf 82' lang='eng' dir='ltr'><strong>City</strong></span></span></p></div></div></body></html>" }
+      let(:expected_return_value) { "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"> <?xml version=\"1.0\" encoding=\"UTF-8\"?><html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\"> <head> <title></title> <meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\"> <meta name=\"ocr-system\" content=\"tesseract 3.04.00\"> <meta name=\"ocr-capabilities\" content=\"ocr_page ocr_carea ocr_par ocr_line ocrx_word\"> </head> <body><div class=\"ocr_page\" id=\"page_1\" title='image \"./1962/5215078g.jpg\"; bbox 0 0 3041 4044; ppageno 0'> <div class=\"ocr_carea\" id=\"block_1_1\" title=\"bbox 0 0 532 404\"><p class=\"ocr_par\" dir=\"ltr\" id=\"par_1_1\" title=\"bbox 0 0 532 404\"><span class=\"ocr_line\" id=\"line_1_1\" title=\"bbox 0 0 532 404; baseline 0 3640\"><span class=\"ocrx_word\" id=\"word_1_1\" title=\"bbox 0 0 532 404; x_wconf 95\" lang=\"eng\" dir=\"ltr\"></span></span></p></div> <div class=\"ocr_carea\" id=\"block_1_2\" title=\"bbox 1249 425 1777 493\"><p class=\"ocr_par\" dir=\"ltr\" id=\"par_1_2\" title=\"bbox 1249 425 1777 493\"><span class=\"ocr_line\" id=\"line_1_2\" title=\"bbox 1249 425 1777 493; baseline 0 -12\"><span class=\"ocrx_word\" id=\"word_1_2\" title=\"bbox 1249 425 1409 483; x_wconf 91\" lang=\"eng\" dir=\"ltr\">New</span><span class=\"ocrx_word\" id=\"word_1_3\" title=\"bbox 1440 426 1604 482; x_wconf 88\" lang=\"eng\" dir=\"ltr\"><strong>York</strong></span><span class=\"ocrx_word\" id=\"word_1_4\" title=\"bbox 1635 425 1777 493; x_wconf 82\" lang=\"eng\" dir=\"ltr\"><strong>City</strong></span></span></p></div> </div></body> </html>" }
+
+      it 'returns the expected unescaped hocr string' do
         expect(subject).to eq(expected_return_value)
       end
     end


### PR DESCRIPTION
Adds support for hocr content.

I've copied all the existing `mets_altos/#{uuid}.xml` to `ocr/<uuid>` in the QA bucket in addition to adding all The Green Books hocr files. By removing the file extension, the S3 client can just fetch the content without needing to know the file extension beforehand.