### PR TITLE
NOREF Fix docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN gem install bundler
 RUN rm /etc/nginx/sites-enabled/default
 ADD ./provisioning/docker_build/fedora_ingest_rails.conf /etc/nginx/sites-enabled/fedora_ingest_rails.conf
 COPY --chown=app:app . /home/app/fedora_ingest_rails
-RUN bundle install -V --without test development
+ENV BUNDLER_WITHOUT="development test"
+RUN bundle install -V
 
 # Enables ngnix+passenger
 RUN rm -f /etc/service/nginx/down

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'redcarpet'
 gem 'rsolr'
 gem 'rsolr-ext'
 gem 'rubydora'
-gem 'stringio', '3.1.7'
+gem 'stringio', '3.2.0'
 
 gem 'aws-sdk-s3'
 gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ GEM
     spring (4.2.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    stringio (3.1.7)
+    stringio (3.2.0)
     thor (1.3.2)
     tilt (2.6.1)
     timeout (0.4.3)
@@ -424,7 +424,7 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-commands-rspec
-  stringio (= 3.1.7)
+  stringio (= 3.2.0)
   tzinfo-data
   uglifier
   web-console


### PR DESCRIPTION
Travis builds were failing with
> ERROR: failed to build: failed to solve: process "/bin/sh -c bundle install -V --without test development" did not complete successfully: exit code: 15

The `--without` flag is deprecated and updated to use an `ENV` variable following https://github.com/rubygems/bundler/issues/7531#issuecomment-571651023.

There was also an issue with the stringio version, but bumping it up to 3.2.0 fixes it.

Can build and run the image locally now.