### PR TITLE
DR-4134 add ocr solr file path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,9 @@ MMS_BASIC_PASSWORD=password
 # Find real value in parameter store /development/fedora_ingest_rails/repo_solr_url
 REPO_SOLR_URL=https://example-solr8.example.org/solr/repoapi_dev
 
+# OCR file path on Solr disk
+OCR_SOLR_FILE_PATH="/file/path/location/on/disk"
+
 # Link minter service
 LINK_USERNAME=link
 LINK_PASSWORD=link

--- a/app/helpers/ingest_job_helper.rb
+++ b/app/helpers/ingest_job_helper.rb
@@ -109,8 +109,9 @@ module IngestJobHelper
         # Get the plain text from the ocr content
         if not ocr_content.nil?
           if ocr_content.include?("<alto>")
+            capture_solr_doc['ocr_text'] = "#{ENV['OCR_SOLR_FILE_PATH']}/ocr/#{uuid}"
             capture_solr_doc['mets_alto'] = ocr_content
-            capture_solr_doc['hasOCR'] = capture_solr_doc['mets_alto'].present?
+            capture_solr_doc['hasOCR'] = true
             capture_solr_doc['captureText_ocrtext'] = Nokogiri::XML(ocr_content).xpath('//String').collect { |s| s.at('@CONTENT').text }.join(" ")
 
           elsif ocr_content.include?("</html>")


### PR DESCRIPTION
[DR-4134](https://newyorkpubliclibrary.atlassian.net/browse/DR-4134)

Set the file path location on Solr's disk to the Solr field `ocr_text`.

Leaving in the `mets_alto` and `hocr` stuff for now as a fallback, but I think once this is working and looks good we can remove those.

[DR-4134]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ